### PR TITLE
Stop integration execution on exporter stopped

### DIFF
--- a/src/exporter/exporter.go
+++ b/src/exporter/exporter.go
@@ -129,3 +129,12 @@ func (e *Exporter) createJobObject() error {
 
 	return nil
 }
+
+// Kill cancel the ctx and close the handle
+func (e *Exporter) Kill() {
+	windows.CloseHandle(e.jobObject)
+	e.cancel()
+	if err := e.cmd.Wait(); err != nil {
+		log.Error(err.Error())
+	}
+}

--- a/src/winservices.go
+++ b/src/winservices.go
@@ -51,6 +51,7 @@ func main() {
 	}
 
 	run(e, i)
+	e.Kill()
 	// Integration exit if there are problems scraping or processing metrics and
 	// is being relaunched by the Agent since no hartbeats are send
 	os.Exit(1)
@@ -60,7 +61,7 @@ func run(e exporter.Exporter, i *integration.Integration) {
 	interval, err := time.ParseDuration(args.ScrapeInterval)
 	if err != nil {
 		log.Error("error parsing ScrapeInterval:", err.Error())
-		os.Exit(1)
+		return
 	}
 	heartBeat := time.NewTicker(heartBeatPeriod)
 	metricInterval := time.NewTicker(interval)


### PR DESCRIPTION
* change behavior to stop the execution of the integration if the exporter is stopped.
* Integration exits with fail if scraper fails to get metrics