### PR TITLE
Add debug msg for empty enum metric

### DIFF
--- a/src/nri/metricsProcesor.go
+++ b/src/nri/metricsProcesor.go
@@ -89,6 +89,7 @@ func processMetricGauge(metricFamily dto.MetricFamily, entityRules EntityRules, 
 	if metricFamily.GetType() != dto.MetricType_GAUGE {
 		return fmt.Errorf("metric type not Gauge")
 	}
+	noMetricAdded := true
 	for _, metric := range metricFamily.GetMetric() {
 		metricValue := metric.GetGauge().GetValue()
 		// skip enum metrics without value
@@ -117,6 +118,10 @@ func processMetricGauge(metricFamily dto.MetricFamily, entityRules EntityRules, 
 		warnOnErr(err)
 		addAttributes(attributes, gauge)
 		e.AddMetric(gauge)
+		noMetricAdded = false
+	}
+	if noMetricAdded && metricRules.EnumMetric {
+		log.Debug("all metrics have value 0 for:%s", metricFamily.GetName())
 	}
 	return nil
 }


### PR DESCRIPTION
This adds a debug message for the case that all enum metrics has value 0

`windows_service_start_mode{name="ktmrm",start_mode="auto"} 0
windows_service_start_mode{name="ktmrm",start_mode="boot"} 0
windows_service_start_mode{name="ktmrm",start_mode="disabled"} 0
windows_service_start_mode{name="ktmrm",start_mode="manual"} 0
windows_service_start_mode{name="ktmrm",start_mode="system"} 0`