### PR TITLE
feat: Added account info for winservice

### DIFF
--- a/src/nri/rules.go
+++ b/src/nri/rules.go
@@ -73,6 +73,11 @@ func loadRules() EntityRules {
 						IsEntityMetadata: true,
 					},
 					{
+						Label:            "run_as",
+						NrdbLabelName:    "windowsService.runAs",
+						IsEntityMetadata: true,
+					},
+					{
 						Label:            "display_name",
 						NrdbLabelName:    "windowsService.displayName",
 						IsEntityMetadata: true,

--- a/src/scraper/testdata/actualOutput
+++ b/src/scraper/testdata/actualOutput
@@ -3,110 +3,110 @@
 go_gc_duration_seconds{quantile="0"} 0
 go_gc_duration_seconds{quantile="0.25"} 0
 go_gc_duration_seconds{quantile="0.5"} 0
-go_gc_duration_seconds{quantile="0.75"} 0
-go_gc_duration_seconds{quantile="1"} 0
-go_gc_duration_seconds_sum 0
-go_gc_duration_seconds_count 7
+go_gc_duration_seconds{quantile="0.75"} 0.0006379
+go_gc_duration_seconds{quantile="1"} 0.0054151
+go_gc_duration_seconds_sum 0.0080109
+go_gc_duration_seconds_count 14
 # HELP go_goroutines Number of goroutines that currently exist.
 # TYPE go_goroutines gauge
-go_goroutines 13
+go_goroutines 8
 # HELP go_info Information about the Go environment.
 # TYPE go_info gauge
-go_info{version="go1.13.6"} 1
+go_info{version="go1.14.2"} 1
 # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
 # TYPE go_memstats_alloc_bytes gauge
-go_memstats_alloc_bytes 2.72696e+06
+go_memstats_alloc_bytes 4.006232e+06
 # HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
 # TYPE go_memstats_alloc_bytes_total counter
-go_memstats_alloc_bytes_total 4.5451144e+07
+go_memstats_alloc_bytes_total 4.4912192e+07
 # HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
 # TYPE go_memstats_buck_hash_sys_bytes gauge
-go_memstats_buck_hash_sys_bytes 1.453558e+06
+go_memstats_buck_hash_sys_bytes 1.453938e+06
 # HELP go_memstats_frees_total Total number of frees.
 # TYPE go_memstats_frees_total counter
-go_memstats_frees_total 62914
+go_memstats_frees_total 60126
 # HELP go_memstats_gc_cpu_fraction The fraction of this program's available CPU time used by the GC since the program started.
 # TYPE go_memstats_gc_cpu_fraction gauge
-go_memstats_gc_cpu_fraction 0.0024155593085851044
+go_memstats_gc_cpu_fraction 0.010391484982753307
 # HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
 # TYPE go_memstats_gc_sys_bytes gauge
-go_memstats_gc_sys_bytes 1.03296e+06
+go_memstats_gc_sys_bytes 1.823384e+06
 # HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
 # TYPE go_memstats_heap_alloc_bytes gauge
-go_memstats_heap_alloc_bytes 2.72696e+06
+go_memstats_heap_alloc_bytes 4.006232e+06
 # HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
 # TYPE go_memstats_heap_idle_bytes gauge
-go_memstats_heap_idle_bytes 2.039808e+07
+go_memstats_heap_idle_bytes 6.5536e+06
 # HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
 # TYPE go_memstats_heap_inuse_bytes gauge
-go_memstats_heap_inuse_bytes 4.538368e+06
+go_memstats_heap_inuse_bytes 5.832704e+06
 # HELP go_memstats_heap_objects Number of allocated objects.
 # TYPE go_memstats_heap_objects gauge
-go_memstats_heap_objects 18122
+go_memstats_heap_objects 28063
 # HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
 # TYPE go_memstats_heap_released_bytes gauge
-go_memstats_heap_released_bytes 2.039808e+07
+go_memstats_heap_released_bytes 3.284992e+06
 # HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
 # TYPE go_memstats_heap_sys_bytes gauge
-go_memstats_heap_sys_bytes 2.4936448e+07
+go_memstats_heap_sys_bytes 1.2386304e+07
 # HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
 # TYPE go_memstats_last_gc_time_seconds gauge
-go_memstats_last_gc_time_seconds 1.5895582977022643e+09
+go_memstats_last_gc_time_seconds 1.591692341305524e+09
 # HELP go_memstats_lookups_total Total number of pointer lookups.
 # TYPE go_memstats_lookups_total counter
 go_memstats_lookups_total 0
 # HELP go_memstats_mallocs_total Total number of mallocs.
 # TYPE go_memstats_mallocs_total counter
-go_memstats_mallocs_total 81036
+go_memstats_mallocs_total 88189
 # HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
 # TYPE go_memstats_mcache_inuse_bytes gauge
-go_memstats_mcache_inuse_bytes 1704
+go_memstats_mcache_inuse_bytes 6816
 # HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
 # TYPE go_memstats_mcache_sys_bytes gauge
 go_memstats_mcache_sys_bytes 16384
 # HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
 # TYPE go_memstats_mspan_inuse_bytes gauge
-go_memstats_mspan_inuse_bytes 69904
+go_memstats_mspan_inuse_bytes 105128
 # HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
 # TYPE go_memstats_mspan_sys_bytes gauge
-go_memstats_mspan_sys_bytes 114688
+go_memstats_mspan_sys_bytes 131072
 # HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
 # TYPE go_memstats_next_gc_bytes gauge
-go_memstats_next_gc_bytes 4.592288e+06
+go_memstats_next_gc_bytes 6.330384e+06
 # HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
 # TYPE go_memstats_other_sys_bytes gauge
-go_memstats_other_sys_bytes 420610
+go_memstats_other_sys_bytes 1.190022e+06
 # HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
 # TYPE go_memstats_stack_inuse_bytes gauge
-go_memstats_stack_inuse_bytes 229376
+go_memstats_stack_inuse_bytes 196608
 # HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
 # TYPE go_memstats_stack_sys_bytes gauge
-go_memstats_stack_sys_bytes 229376
+go_memstats_stack_sys_bytes 196608
 # HELP go_memstats_sys_bytes Number of bytes obtained from system.
 # TYPE go_memstats_sys_bytes gauge
-go_memstats_sys_bytes 2.8204024e+07
+go_memstats_sys_bytes 1.7197712e+07
 # HELP go_threads Number of OS threads created.
 # TYPE go_threads gauge
-go_threads 7
+go_threads 9
 # HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
 # TYPE process_start_time_seconds counter
-process_start_time_seconds 1.589558298e+09
+process_start_time_seconds 1.591692341e+09
 # HELP windows_cs_hostname Labeled system hostname information as provided by ComputerSystem.DNSHostName and ComputerSystem.Domain
 # TYPE windows_cs_hostname gauge
-windows_cs_hostname{domain="WORKGROUP",fqdn="WIN-CEBI3UOM5B8",hostname="WIN-CEBI3UOM5B8"} 1
+windows_cs_hostname{domain="WORKGROUP",fqdn="DESKTOP-LROUA52",hostname="DESKTOP-LROUA52"} 1
 # HELP windows_cs_logical_processors ComputerSystem.NumberOfLogicalProcessors
 # TYPE windows_cs_logical_processors gauge
-windows_cs_logical_processors 1
+windows_cs_logical_processors 4
 # HELP windows_cs_physical_memory_bytes ComputerSystem.TotalPhysicalMemory
 # TYPE windows_cs_physical_memory_bytes gauge
-windows_cs_physical_memory_bytes 1.073270784e+09
+windows_cs_physical_memory_bytes 7.347949568e+09
 # HELP windows_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which windows_exporter was built.
 # TYPE windows_exporter_build_info gauge
-windows_exporter_build_info{branch="master",goversion="go1.13.6",revision="99ed969bf79e8cf344a7ae715176043e624cf8af",version="0.11.1-4-g99ed969-dirty"} 1
+windows_exporter_build_info{branch="HEAD",goversion="go1.14.2",revision="c9f1e5068a267aeb3e8cff47bc5323cbc050055a",version="0.13.0-10-gc9f1e50-dirty"} 1
 # HELP windows_exporter_collector_duration_seconds windows_exporter: Duration of a collection.
 # TYPE windows_exporter_collector_duration_seconds gauge
-windows_exporter_collector_duration_seconds{collector="cs"} 0.7333529
-windows_exporter_collector_duration_seconds{collector="service"} 0.7307001
+windows_exporter_collector_duration_seconds{collector="cs"} 0.0419192
+windows_exporter_collector_duration_seconds{collector="service"} 1.0149909
 # HELP windows_exporter_collector_success windows_exporter: Whether the collector was successful.
 # TYPE windows_exporter_collector_success gauge
 windows_exporter_collector_success{collector="cs"} 1
@@ -117,206 +117,270 @@ windows_exporter_collector_timeout{collector="cs"} 0
 windows_exporter_collector_timeout{collector="service"} 0
 # HELP windows_exporter_perflib_snapshot_duration_seconds Duration of perflib snapshot capture
 # TYPE windows_exporter_perflib_snapshot_duration_seconds gauge
-windows_exporter_perflib_snapshot_duration_seconds 0.8506004
+windows_exporter_perflib_snapshot_duration_seconds 0.4359746
 # HELP windows_service_info A metric with a constant '1' value labeled with service information
 # TYPE windows_service_info gauge
-windows_service_info{display_name="ActiveX Installer (AxInstSV)",name="axinstsv",process_id="0"} 1
-windows_service_info{display_name="AllJoyn Router Service",name="ajrouter",process_id="0"} 1
-windows_service_info{display_name="App Readiness",name="appreadiness",process_id="0"} 1
-windows_service_info{display_name="AppX Deployment Service (AppXSVC)",name="appxsvc",process_id="0"} 1
-windows_service_info{display_name="Application Host Helper Service",name="apphostsvc",process_id="168"} 1
-windows_service_info{display_name="Application Identity",name="appidsvc",process_id="0"} 1
-windows_service_info{display_name="Application Information",name="appinfo",process_id="0"} 1
-windows_service_info{display_name="Application Layer Gateway Service",name="alg",process_id="0"} 1
-windows_service_info{display_name="Application Management",name="appmgmt",process_id="436"} 1
-windows_service_info{display_name="Auto Time Zone Updater",name="tzautoupdate",process_id="0"} 1
-windows_service_info{display_name="Background Intelligent Transfer Service",name="bits",process_id="0"} 1
-windows_service_info{display_name="Background Tasks Infrastructure Service",name="brokerinfrastructure",process_id="632"} 1
-windows_service_info{display_name="Base Filtering Engine",name="bfe",process_id="888"} 1
-windows_service_info{display_name="Bluetooth Support Service",name="bthserv",process_id="0"} 1
-windows_service_info{display_name="CDPUserSvc_225e3",name="cdpusersvc_225e3",process_id="2332"} 1
-windows_service_info{display_name="CNG Key Isolation",name="keyiso",process_id="560"} 1
-windows_service_info{display_name="COM+ Event System",name="eventsystem",process_id="300"} 1
-windows_service_info{display_name="COM+ System Application",name="comsysapp",process_id="0"} 1
-windows_service_info{display_name="Certificate Propagation",name="certpropsvc",process_id="0"} 1
-windows_service_info{display_name="Client License Service (ClipSVC)",name="clipsvc",process_id="0"} 1
-windows_service_info{display_name="Computer Browser",name="browser",process_id="0"} 1
-windows_service_info{display_name="Connected Devices Platform Service",name="cdpsvc",process_id="300"} 1
-windows_service_info{display_name="Connected User Experiences and Telemetry",name="diagtrack",process_id="1504"} 1
-windows_service_info{display_name="Contact Data_225e3",name="pimindexmaintenancesvc_225e3",process_id="0"} 1
-windows_service_info{display_name="CoreMessaging",name="coremessagingregistrar",process_id="888"} 1
-windows_service_info{display_name="Credential Manager",name="vaultsvc",process_id="560"} 1
-windows_service_info{display_name="Cryptographic Services",name="cryptsvc",process_id="772"} 1
-windows_service_info{display_name="DCOM Server Process Launcher",name="dcomlaunch",process_id="632"} 1
-windows_service_info{display_name="DHCP Client",name="dhcp",process_id="992"} 1
-windows_service_info{display_name="DNS Client",name="dnscache",process_id="772"} 1
-windows_service_info{display_name="Data Sharing Service",name="dssvc",process_id="0"} 1
-windows_service_info{display_name="DataCollectionPublishingService",name="dcpsvc",process_id="0"} 1
-windows_service_info{display_name="DevQuery Background Discovery Broker",name="devquerybroker",process_id="0"} 1
-windows_service_info{display_name="Device Association Service",name="deviceassociationservice",process_id="0"} 1
-windows_service_info{display_name="Device Install Service",name="deviceinstall",process_id="0"} 1
-windows_service_info{display_name="Device Management Enrollment Service",name="dmenrollmentsvc",process_id="0"} 1
-windows_service_info{display_name="Device Setup Manager",name="dsmsvc",process_id="0"} 1
-windows_service_info{display_name="Diagnostic Policy Service",name="dps",process_id="888"} 1
-windows_service_info{display_name="Diagnostic Service Host",name="wdiservicehost",process_id="0"} 1
-windows_service_info{display_name="Diagnostic System Host",name="wdisystemhost",process_id="876"} 1
-windows_service_info{display_name="Distributed Link Tracking Client",name="trkwks",process_id="876"} 1
-windows_service_info{display_name="Distributed Transaction Coordinator",name="msdtc",process_id="2088"} 1
-windows_service_info{display_name="Downloaded Maps Manager",name="mapsbroker",process_id="0"} 1
-windows_service_info{display_name="Embedded Mode",name="embeddedmode",process_id="0"} 1
-windows_service_info{display_name="Encrypting File System (EFS)",name="efs",process_id="0"} 1
-windows_service_info{display_name="Enterprise App Management Service",name="entappsvc",process_id="0"} 1
-windows_service_info{display_name="Extensible Authentication Protocol",name="eaphost",process_id="0"} 1
-windows_service_info{display_name="Function Discovery Provider Host",name="fdphost",process_id="300"} 1
-windows_service_info{display_name="Function Discovery Resource Publication",name="fdrespub",process_id="0"} 1
-windows_service_info{display_name="Geolocation Service",name="lfsvc",process_id="436"} 1
-windows_service_info{display_name="Group Policy Client",name="gpsvc",process_id="436"} 1
-windows_service_info{display_name="HV Host Service",name="hvhost",process_id="0"} 1
-windows_service_info{display_name="Human Interface Device Service",name="hidserv",process_id="0"} 1
-windows_service_info{display_name="Hyper-V Data Exchange Service",name="vmickvpexchange",process_id="0"} 1
-windows_service_info{display_name="Hyper-V Guest Service Interface",name="vmicguestinterface",process_id="0"} 1
-windows_service_info{display_name="Hyper-V Guest Shutdown Service",name="vmicshutdown",process_id="0"} 1
-windows_service_info{display_name="Hyper-V Heartbeat Service",name="vmicheartbeat",process_id="0"} 1
-windows_service_info{display_name="Hyper-V PowerShell Direct Service",name="vmicvmsession",process_id="0"} 1
-windows_service_info{display_name="Hyper-V Remote Desktop Virtualization Service",name="vmicrdv",process_id="0"} 1
-windows_service_info{display_name="Hyper-V Time Synchronization Service",name="vmictimesync",process_id="0"} 1
-windows_service_info{display_name="Hyper-V Volume Shadow Copy Requestor",name="vmicvss",process_id="0"} 1
-windows_service_info{display_name="IKE and AuthIP IPsec Keying Modules",name="ikeext",process_id="436"} 1
-windows_service_info{display_name="IP Helper",name="iphlpsvc",process_id="436"} 1
-windows_service_info{display_name="IPsec Policy Agent",name="policyagent",process_id="3140"} 1
-windows_service_info{display_name="Interactive Services Detection",name="ui0detect",process_id="0"} 1
-windows_service_info{display_name="Internet Connection Sharing (ICS)",name="sharedaccess",process_id="0"} 1
-windows_service_info{display_name="KDC Proxy Server service (KPS)",name="kpssvc",process_id="0"} 1
-windows_service_info{display_name="KtmRm for Distributed Transaction Coordinator",name="ktmrm",process_id="0"} 1
-windows_service_info{display_name="Link-Layer Topology Discovery Mapper",name="lltdsvc",process_id="0"} 1
-windows_service_info{display_name="Local Session Manager",name="lsm",process_id="632"} 1
-windows_service_info{display_name="Microsoft (R) Diagnostics Hub Standard Collector Service",name="diagnosticshub.standardcollector.service",process_id="0"} 1
-windows_service_info{display_name="Microsoft Account Sign-in Assistant",name="wlidsvc",process_id="0"} 1
-windows_service_info{display_name="Microsoft App-V Client",name="appvclient",process_id="0"} 1
-windows_service_info{display_name="Microsoft Passport",name="ngcsvc",process_id="0"} 1
-windows_service_info{display_name="Microsoft Passport Container",name="ngcctnrsvc",process_id="0"} 1
-windows_service_info{display_name="Microsoft Software Shadow Copy Provider",name="swprv",process_id="0"} 1
-windows_service_info{display_name="Microsoft Storage Spaces SMP",name="smphost",process_id="0"} 1
-windows_service_info{display_name="Microsoft iSCSI Initiator Service",name="msiscsi",process_id="0"} 1
-windows_service_info{display_name="Net.Tcp Port Sharing Service",name="nettcpportsharing",process_id="0"} 1
-windows_service_info{display_name="Netlogon",name="netlogon",process_id="0"} 1
-windows_service_info{display_name="Network Connection Broker",name="ncbservice",process_id="876"} 1
-windows_service_info{display_name="Network Connections",name="netman",process_id="0"} 1
-windows_service_info{display_name="Network Connectivity Assistant",name="ncasvc",process_id="0"} 1
-windows_service_info{display_name="Network List Service",name="netprofm",process_id="300"} 1
-windows_service_info{display_name="Network Location Awareness",name="nlasvc",process_id="772"} 1
-windows_service_info{display_name="Network Setup Service",name="netsetupsvc",process_id="0"} 1
-windows_service_info{display_name="Network Store Interface Service",name="nsi",process_id="300"} 1
-windows_service_info{display_name="New Relic Infrastructure Agent",name="newrelic-infra",process_id="4844"} 1
-windows_service_info{display_name="Offline Files",name="cscservice",process_id="0"} 1
-windows_service_info{display_name="Optimize drives",name="defragsvc",process_id="0"} 1
-windows_service_info{display_name="Performance Counter DLL Host",name="perfhost",process_id="0"} 1
-windows_service_info{display_name="Performance Logs & Alerts",name="pla",process_id="0"} 1
-windows_service_info{display_name="Phone Service",name="phonesvc",process_id="0"} 1
-windows_service_info{display_name="Plug and Play",name="plugplay",process_id="632"} 1
-windows_service_info{display_name="Portable Device Enumerator Service",name="wpdbusenum",process_id="0"} 1
-windows_service_info{display_name="Power",name="power",process_id="632"} 1
-windows_service_info{display_name="Print Spooler",name="spooler",process_id="1400"} 1
-windows_service_info{display_name="Printer Extensions and Notifications",name="printnotify",process_id="0"} 1
-windows_service_info{display_name="Problem Reports and Solutions Control Panel Support",name="wercplsupport",process_id="0"} 1
-windows_service_info{display_name="Program Compatibility Assistant Service",name="pcasvc",process_id="876"} 1
-windows_service_info{display_name="Quality Windows Audio Video Experience",name="qwave",process_id="0"} 1
-windows_service_info{display_name="RPC Endpoint Mapper",name="rpceptmapper",process_id="668"} 1
-windows_service_info{display_name="Radio Management Service",name="rmsvc",process_id="0"} 1
-windows_service_info{display_name="Remote Access Auto Connection Manager",name="rasauto",process_id="0"} 1
-windows_service_info{display_name="Remote Access Connection Manager",name="rasman",process_id="0"} 1
-windows_service_info{display_name="Remote Desktop Configuration",name="sessionenv",process_id="0"} 1
-windows_service_info{display_name="Remote Desktop Services",name="termservice",process_id="0"} 1
-windows_service_info{display_name="Remote Desktop Services UserMode Port Redirector",name="umrdpservice",process_id="0"} 1
-windows_service_info{display_name="Remote Procedure Call (RPC)",name="rpcss",process_id="668"} 1
-windows_service_info{display_name="Remote Procedure Call (RPC) Locator",name="rpclocator",process_id="0"} 1
-windows_service_info{display_name="Remote Registry",name="remoteregistry",process_id="0"} 1
-windows_service_info{display_name="Resultant Set of Policy Provider",name="rsopprov",process_id="0"} 1
-windows_service_info{display_name="Routing and Remote Access",name="remoteaccess",process_id="0"} 1
-windows_service_info{display_name="SNMP Trap",name="snmptrap",process_id="0"} 1
-windows_service_info{display_name="SSDP Discovery",name="ssdpsrv",process_id="3820"} 1
-windows_service_info{display_name="Secondary Logon",name="seclogon",process_id="0"} 1
-windows_service_info{display_name="Secure Socket Tunneling Protocol Service",name="sstpsvc",process_id="0"} 1
-windows_service_info{display_name="Security Accounts Manager",name="samss",process_id="560"} 1
-windows_service_info{display_name="Sensor Data Service",name="sensordataservice",process_id="0"} 1
-windows_service_info{display_name="Sensor Monitoring Service",name="sensrsvc",process_id="0"} 1
-windows_service_info{display_name="Sensor Service",name="sensorservice",process_id="0"} 1
-windows_service_info{display_name="Server",name="lanmanserver",process_id="1516"} 1
-windows_service_info{display_name="Shell Hardware Detection",name="shellhwdetection",process_id="436"} 1
-windows_service_info{display_name="Smart Card",name="scardsvr",process_id="0"} 1
-windows_service_info{display_name="Smart Card Device Enumeration Service",name="scdeviceenum",process_id="0"} 1
-windows_service_info{display_name="Smart Card Removal Policy",name="scpolicysvc",process_id="0"} 1
-windows_service_info{display_name="Software Protection",name="sppsvc",process_id="0"} 1
-windows_service_info{display_name="Special Administration Console Helper",name="sacsvr",process_id="0"} 1
-windows_service_info{display_name="Spot Verifier",name="svsvc",process_id="0"} 1
-windows_service_info{display_name="State Repository Service",name="staterepository",process_id="1620"} 1
-windows_service_info{display_name="Still Image Acquisition Events",name="wiarpc",process_id="0"} 1
-windows_service_info{display_name="Storage Service",name="storsvc",process_id="876"} 1
-windows_service_info{display_name="Storage Tiers Management",name="tieringengineservice",process_id="0"} 1
-windows_service_info{display_name="Superfetch",name="sysmain",process_id="0"} 1
-windows_service_info{display_name="Sync Host_225e3",name="onesyncsvc_225e3",process_id="2332"} 1
-windows_service_info{display_name="System Event Notification Service",name="sens",process_id="436"} 1
-windows_service_info{display_name="System Events Broker",name="systemeventsbroker",process_id="632"} 1
-windows_service_info{display_name="TCP/IP NetBIOS Helper",name="lmhosts",process_id="992"} 1
-windows_service_info{display_name="Task Scheduler",name="schedule",process_id="436"} 1
-windows_service_info{display_name="Telephony",name="tapisrv",process_id="0"} 1
-windows_service_info{display_name="Themes",name="themes",process_id="436"} 1
-windows_service_info{display_name="Tile Data model server",name="tiledatamodelsvc",process_id="1620"} 1
-windows_service_info{display_name="Time Broker",name="timebrokersvc",process_id="992"} 1
-windows_service_info{display_name="Touch Keyboard and Handwriting Panel Service",name="tabletinputservice",process_id="0"} 1
-windows_service_info{display_name="UPnP Device Host",name="upnphost",process_id="0"} 1
-windows_service_info{display_name="Update Orchestrator Service for Windows Update",name="usosvc",process_id="0"} 1
-windows_service_info{display_name="User Access Logging Service",name="ualsvc",process_id="876"} 1
-windows_service_info{display_name="User Data Access_225e3",name="userdatasvc_225e3",process_id="0"} 1
-windows_service_info{display_name="User Data Storage_225e3",name="unistoresvc_225e3",process_id="0"} 1
-windows_service_info{display_name="User Experience Virtualization Service",name="uevagentservice",process_id="0"} 1
-windows_service_info{display_name="User Manager",name="usermanager",process_id="436"} 1
-windows_service_info{display_name="User Profile Service",name="profsvc",process_id="436"} 1
-windows_service_info{display_name="Virtual Disk",name="vds",process_id="0"} 1
-windows_service_info{display_name="VirtualBox Guest Additions Service",name="vboxservice",process_id="1016"} 1
-windows_service_info{display_name="Volume Shadow Copy",name="vss",process_id="0"} 1
-windows_service_info{display_name="W3C Logging Service",name="w3logsvc",process_id="0"} 1
-windows_service_info{display_name="WMI Performance Adapter",name="wmiapsrv",process_id="4280"} 1
-windows_service_info{display_name="WMI exporter",name="windows_exporter",process_id="0"} 1
-windows_service_info{display_name="WalletService",name="walletservice",process_id="0"} 1
-windows_service_info{display_name="WinHTTP Web Proxy Auto-Discovery Service",name="winhttpautoproxysvc",process_id="300"} 1
-windows_service_info{display_name="Windows Audio",name="audiosrv",process_id="0"} 1
-windows_service_info{display_name="Windows Audio Endpoint Builder",name="audioendpointbuilder",process_id="0"} 1
-windows_service_info{display_name="Windows Biometric Service",name="wbiosrvc",process_id="0"} 1
-windows_service_info{display_name="Windows Camera Frame Server",name="frameserver",process_id="0"} 1
-windows_service_info{display_name="Windows Connection Manager",name="wcmsvc",process_id="1028"} 1
-windows_service_info{display_name="Windows Defender Network Inspection Service",name="wdnissvc",process_id="0"} 1
-windows_service_info{display_name="Windows Defender Service",name="windefend",process_id="1628"} 1
-windows_service_info{display_name="Windows Driver Foundation - User-mode Driver Framework",name="wudfsvc",process_id="0"} 1
-windows_service_info{display_name="Windows Encryption Provider Host Service",name="wephostsvc",process_id="0"} 1
-windows_service_info{display_name="Windows Error Reporting Service",name="wersvc",process_id="0"} 1
-windows_service_info{display_name="Windows Event Collector",name="wecsvc",process_id="0"} 1
-windows_service_info{display_name="Windows Event Log",name="eventlog",process_id="992"} 1
-windows_service_info{display_name="Windows Firewall",name="mpssvc",process_id="888"} 1
-windows_service_info{display_name="Windows Font Cache Service",name="fontcache",process_id="300"} 1
-windows_service_info{display_name="Windows Image Acquisition (WIA)",name="stisvc",process_id="0"} 1
-windows_service_info{display_name="Windows Insider Service",name="wisvc",process_id="0"} 1
-windows_service_info{display_name="Windows Installer",name="msiserver",process_id="0"} 1
-windows_service_info{display_name="Windows License Manager Service",name="licensemanager",process_id="0"} 1
-windows_service_info{display_name="Windows Licensing Monitoring Service",name="wlms",process_id="1640"} 1
-windows_service_info{display_name="Windows Management Instrumentation",name="winmgmt",process_id="436"} 1
-windows_service_info{display_name="Windows Mobile Hotspot Service",name="icssvc",process_id="0"} 1
-windows_service_info{display_name="Windows Modules Installer",name="trustedinstaller",process_id="0"} 1
-windows_service_info{display_name="Windows Process Activation Service",name="was",process_id="2880"} 1
-windows_service_info{display_name="Windows Push Notifications System Service",name="wpnservice",process_id="436"} 1
-windows_service_info{display_name="Windows Push Notifications User Service_225e3",name="wpnuserservice_225e3",process_id="0"} 1
-windows_service_info{display_name="Windows Remote Management (WS-Management)",name="winrm",process_id="772"} 1
-windows_service_info{display_name="Windows Search",name="wsearch",process_id="0"} 1
-windows_service_info{display_name="Windows Time",name="w32time",process_id="300"} 1
-windows_service_info{display_name="Windows Update",name="wuauserv",process_id="0"} 1
-windows_service_info{display_name="Wired AutoConfig",name="dot3svc",process_id="0"} 1
-windows_service_info{display_name="Workstation",name="lanmanworkstation",process_id="772"} 1
-windows_service_info{display_name="World Wide Web Publishing Service",name="w3svc",process_id="2880"} 1
-windows_service_info{display_name="Xbox Live Auth Manager",name="xblauthmanager",process_id="0"} 1
-windows_service_info{display_name="Xbox Live Game Save",name="xblgamesave",process_id="0"} 1
-windows_service_info{display_name="dmwappushsvc",name="dmwappushservice",process_id="0"} 1
+windows_service_info{display_name="AVCTP service",name="bthavctpsvc",process_id="5040",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="ActiveX Installer (AxInstSV)",name="axinstsv",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Agent Activation Runtime_390e7",name="aarsvc_390e7",process_id="0",run_as=""} 1
+windows_service_info{display_name="AllJoyn Router Service",name="ajrouter",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="App Readiness",name="appreadiness",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="AppX Deployment Service (AppXSVC)",name="appxsvc",process_id="1092",run_as="LocalSystem"} 1
+windows_service_info{display_name="Application Identity",name="appidsvc",process_id="0",run_as="NT Authority\\LocalService"} 1
+windows_service_info{display_name="Application Information",name="appinfo",process_id="2680",run_as="LocalSystem"} 1
+windows_service_info{display_name="Application Layer Gateway Service",name="alg",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Application Management",name="appmgmt",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="AssignedAccessManager Service",name="assignedaccessmanagersvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Auto Time Zone Updater",name="tzautoupdate",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Background Intelligent Transfer Service",name="bits",process_id="6320",run_as="LocalSystem"} 1
+windows_service_info{display_name="Background Tasks Infrastructure Service",name="brokerinfrastructure",process_id="884",run_as="LocalSystem"} 1
+windows_service_info{display_name="Base Filtering Engine",name="bfe",process_id="2668",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="BitLocker Drive Encryption Service",name="bdesvc",process_id="0",run_as="localSystem"} 1
+windows_service_info{display_name="Block Level Backup Engine Service",name="wbengine",process_id="0",run_as="localSystem"} 1
+windows_service_info{display_name="Bluetooth Audio Gateway Service",name="btagservice",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Bluetooth Support Service",name="bthserv",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Bluetooth User Support Service_390e7",name="bluetoothuserservice_390e7",process_id="0",run_as=""} 1
+windows_service_info{display_name="BranchCache",name="peerdistsvc",process_id="0",run_as="NT AUTHORITY\\NetworkService"} 1
+windows_service_info{display_name="CNG Key Isolation",name="keyiso",process_id="676",run_as="LocalSystem"} 1
+windows_service_info{display_name="COM+ Event System",name="eventsystem",process_id="1932",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="COM+ System Application",name="comsysapp",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Capability Access Manager Service",name="camsvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="CaptureService_390e7",name="captureservice_390e7",process_id="0",run_as=""} 1
+windows_service_info{display_name="Cellular Time",name="autotimesvc",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Certificate Propagation",name="certpropsvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Client License Service (ClipSVC)",name="clipsvc",process_id="1192",run_as="LocalSystem"} 1
+windows_service_info{display_name="Clipboard User Service_390e7",name="cbdhsvc_390e7",process_id="4772",run_as=""} 1
+windows_service_info{display_name="Connected Devices Platform Service",name="cdpsvc",process_id="4472",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Connected Devices Platform User Service_390e7",name="cdpusersvc_390e7",process_id="1260",run_as=""} 1
+windows_service_info{display_name="Connected User Experiences and Telemetry",name="diagtrack",process_id="2848",run_as="LocalSystem"} 1
+windows_service_info{display_name="ConsentUX_390e7",name="consentuxusersvc_390e7",process_id="0",run_as=""} 1
+windows_service_info{display_name="Contact Data_390e7",name="pimindexmaintenancesvc_390e7",process_id="0",run_as=""} 1
+windows_service_info{display_name="CoreMessaging",name="coremessagingregistrar",process_id="1168",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Credential Manager",name="vaultsvc",process_id="676",run_as="LocalSystem"} 1
+windows_service_info{display_name="CredentialEnrollmentManagerUserSvc_390e7",name="credentialenrollmentmanagerusersvc_390e7",process_id="0",run_as=""} 1
+windows_service_info{display_name="Cryptographic Services",name="cryptsvc",process_id="2828",run_as="NT Authority\\NetworkService"} 1
+windows_service_info{display_name="DCOM Server Process Launcher",name="dcomlaunch",process_id="884",run_as="LocalSystem"} 1
+windows_service_info{display_name="DHCP Client",name="dhcp",process_id="1532",run_as="NT Authority\\LocalService"} 1
+windows_service_info{display_name="DNS Client",name="dnscache",process_id="1744",run_as="NT AUTHORITY\\NetworkService"} 1
+windows_service_info{display_name="Data Sharing Service",name="dssvc",process_id="528",run_as="LocalSystem"} 1
+windows_service_info{display_name="Data Usage",name="dusmsvc",process_id="2380",run_as="NT Authority\\LocalService"} 1
+windows_service_info{display_name="Delivery Optimization",name="dosvc",process_id="640",run_as="NT Authority\\NetworkService"} 1
+windows_service_info{display_name="DevQuery Background Discovery Broker",name="devquerybroker",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Device Association Service",name="deviceassociationservice",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Device Install Service",name="deviceinstall",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Device Management Enrollment Service",name="dmenrollmentsvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Device Management Wireless Application Protocol (WAP) Push message Routing Service",name="dmwappushservice",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Device Setup Manager",name="dsmsvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="DeviceAssociationBroker_390e7",name="deviceassociationbrokersvc_390e7",process_id="0",run_as=""} 1
+windows_service_info{display_name="DevicePicker_390e7",name="devicepickerusersvc_390e7",process_id="0",run_as=""} 1
+windows_service_info{display_name="DevicesFlow_390e7",name="devicesflowusersvc_390e7",process_id="0",run_as=""} 1
+windows_service_info{display_name="Diagnostic Execution Service",name="diagsvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Diagnostic Policy Service",name="dps",process_id="2840",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Diagnostic Service Host",name="wdiservicehost",process_id="3144",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Diagnostic System Host",name="wdisystemhost",process_id="3188",run_as="LocalSystem"} 1
+windows_service_info{display_name="Display Enhancement Service",name="displayenhancementservice",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Display Policy Service",name="dispbrokerdesktopsvc",process_id="1496",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Distributed Link Tracking Client",name="trkwks",process_id="2940",run_as="LocalSystem"} 1
+windows_service_info{display_name="Distributed Transaction Coordinator",name="msdtc",process_id="0",run_as="NT AUTHORITY\\NetworkService"} 1
+windows_service_info{display_name="Downloaded Maps Manager",name="mapsbroker",process_id="0",run_as="NT AUTHORITY\\NetworkService"} 1
+windows_service_info{display_name="Embedded Mode",name="embeddedmode",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Encrypting File System (EFS)",name="efs",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Enterprise App Management Service",name="entappsvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Extensible Authentication Protocol",name="eaphost",process_id="0",run_as="localSystem"} 1
+windows_service_info{display_name="Fax",name="fax",process_id="0",run_as="NT AUTHORITY\\NetworkService"} 1
+windows_service_info{display_name="File History Service",name="fhsvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Function Discovery Provider Host",name="fdphost",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Function Discovery Resource Publication",name="fdrespub",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="GameDVR and Broadcast User Service_390e7",name="bcastdvruserservice_390e7",process_id="0",run_as=""} 1
+windows_service_info{display_name="Geolocation Service",name="lfsvc",process_id="312",run_as="LocalSystem"} 1
+windows_service_info{display_name="GraphicsPerfSvc",name="graphicsperfsvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Group Policy Client",name="gpsvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="HV Host Service",name="hvhost",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Human Interface Device Service",name="hidserv",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Hyper-V Data Exchange Service",name="vmickvpexchange",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Hyper-V Guest Service Interface",name="vmicguestinterface",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Hyper-V Guest Shutdown Service",name="vmicshutdown",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Hyper-V Heartbeat Service",name="vmicheartbeat",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Hyper-V PowerShell Direct Service",name="vmicvmsession",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Hyper-V Remote Desktop Virtualization Service",name="vmicrdv",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Hyper-V Time Synchronization Service",name="vmictimesync",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Hyper-V Volume Shadow Copy Requestor",name="vmicvss",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="IKE and AuthIP IPsec Keying Modules",name="ikeext",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="IP Helper",name="iphlpsvc",process_id="2340",run_as="LocalSystem"} 1
+windows_service_info{display_name="IP Translation Configuration Service",name="ipxlatcfgsvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="IPsec Policy Agent",name="policyagent",process_id="0",run_as="NT Authority\\NetworkService"} 1
+windows_service_info{display_name="Internet Connection Sharing (ICS)",name="sharedaccess",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="KtmRm for Distributed Transaction Coordinator",name="ktmrm",process_id="0",run_as="NT AUTHORITY\\NetworkService"} 1
+windows_service_info{display_name="LSM",name="lsm",process_id="1000",run_as=""} 1
+windows_service_info{display_name="Language Experience Service",name="lxpsvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Link-Layer Topology Discovery Mapper",name="lltdsvc",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Local Profile Assistant Service",name="wlpasvc",process_id="0",run_as="NT Authority\\LocalService"} 1
+windows_service_info{display_name="MessagingService_390e7",name="messagingservice_390e7",process_id="0",run_as=""} 1
+windows_service_info{display_name="Microsoft (R) Diagnostics Hub Standard Collector Service",name="diagnosticshub.standardcollector.service",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Microsoft Account Sign-in Assistant",name="wlidsvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Microsoft App-V Client",name="appvclient",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Microsoft Passport",name="ngcsvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Microsoft Passport Container",name="ngcctnrsvc",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Microsoft Software Shadow Copy Provider",name="swprv",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Microsoft Storage Spaces SMP",name="smphost",process_id="0",run_as="NT AUTHORITY\\NetworkService"} 1
+windows_service_info{display_name="Microsoft Store Install Service",name="installservice",process_id="3160",run_as="LocalSystem"} 1
+windows_service_info{display_name="Microsoft Windows SMS Router Service.",name="smsrouter",process_id="0",run_as="NT Authority\\LocalService"} 1
+windows_service_info{display_name="Microsoft iSCSI Initiator Service",name="msiscsi",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Mozilla Maintenance Service",name="mozillamaintenance",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Natural Authentication",name="naturalauthentication",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Net.Tcp Port Sharing Service",name="nettcpportsharing",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="NetSetupSvc",name="netsetupsvc",process_id="0",run_as=""} 1
+windows_service_info{display_name="Netlogon",name="netlogon",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Network Connected Devices Auto-Setup",name="ncdautosetup",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Network Connection Broker",name="ncbservice",process_id="1236",run_as="LocalSystem"} 1
+windows_service_info{display_name="Network Connections",name="netman",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Network Connectivity Assistant",name="ncasvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Network List Service",name="netprofm",process_id="1920",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Network Location Awareness",name="nlasvc",process_id="1712",run_as="NT AUTHORITY\\NetworkService"} 1
+windows_service_info{display_name="Network Store Interface Service",name="nsi",process_id="1408",run_as="NT Authority\\LocalService"} 1
+windows_service_info{display_name="New Relic Infrastructure Agent",name="newrelic-infra",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Offline Files",name="cscservice",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="OpenSSH Authentication Agent",name="ssh-agent",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Optimize drives",name="defragsvc",process_id="0",run_as="localSystem"} 1
+windows_service_info{display_name="PNRP Machine Name Publication Service",name="pnrpautoreg",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Parental Controls",name="wpcmonsvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Payments and NFC/SE Manager",name="semgrsvc",process_id="2140",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Peer Name Resolution Protocol",name="pnrpsvc",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Peer Networking Grouping",name="p2psvc",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Peer Networking Identity Manager",name="p2pimsvc",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Performance Counter DLL Host",name="perfhost",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Performance Logs & Alerts",name="pla",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Phone Service",name="phonesvc",process_id="0",run_as="NT Authority\\LocalService"} 1
+windows_service_info{display_name="Plug and Play",name="plugplay",process_id="808",run_as="LocalSystem"} 1
+windows_service_info{display_name="Portable Device Enumerator Service",name="wpdbusenum",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Power",name="power",process_id="884",run_as="LocalSystem"} 1
+windows_service_info{display_name="Print Spooler",name="spooler",process_id="2580",run_as="LocalSystem"} 1
+windows_service_info{display_name="PrintWorkflow_390e7",name="printworkflowusersvc_390e7",process_id="0",run_as=""} 1
+windows_service_info{display_name="Printer Extensions and Notifications",name="printnotify",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Problem Reports and Solutions Control Panel Support",name="wercplsupport",process_id="0",run_as="localSystem"} 1
+windows_service_info{display_name="Program Compatibility Assistant Service",name="pcasvc",process_id="4188",run_as="LocalSystem"} 1
+windows_service_info{display_name="Quality Windows Audio Video Experience",name="qwave",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="RPC Endpoint Mapper",name="rpceptmapper",process_id="952",run_as="NT AUTHORITY\\NetworkService"} 1
+windows_service_info{display_name="Radio Management Service",name="rmsvc",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Recommended Troubleshooting Service",name="troubleshootingsvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Remote Access Auto Connection Manager",name="rasauto",process_id="0",run_as="localSystem"} 1
+windows_service_info{display_name="Remote Access Connection Manager",name="rasman",process_id="0",run_as="localSystem"} 1
+windows_service_info{display_name="Remote Desktop Configuration",name="sessionenv",process_id="0",run_as="localSystem"} 1
+windows_service_info{display_name="Remote Desktop Services",name="termservice",process_id="0",run_as="NT Authority\\NetworkService"} 1
+windows_service_info{display_name="Remote Desktop Services UserMode Port Redirector",name="umrdpservice",process_id="0",run_as="localSystem"} 1
+windows_service_info{display_name="Remote Procedure Call (RPC)",name="rpcss",process_id="952",run_as="NT AUTHORITY\\NetworkService"} 1
+windows_service_info{display_name="Remote Procedure Call (RPC) Locator",name="rpclocator",process_id="0",run_as="NT AUTHORITY\\NetworkService"} 1
+windows_service_info{display_name="Remote Registry",name="remoteregistry",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Retail Demo Service",name="retaildemo",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Routing and Remote Access",name="remoteaccess",process_id="0",run_as="localSystem"} 1
+windows_service_info{display_name="SNMP Trap",name="snmptrap",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="SSDP Discovery",name="ssdpsrv",process_id="1048",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Secondary Logon",name="seclogon",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Secure Socket Tunneling Protocol Service",name="sstpsvc",process_id="0",run_as="NT Authority\\LocalService"} 1
+windows_service_info{display_name="Security Accounts Manager",name="samss",process_id="676",run_as="LocalSystem"} 1
+windows_service_info{display_name="Security Center",name="wscsvc",process_id="3212",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Sensor Data Service",name="sensordataservice",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Sensor Monitoring Service",name="sensrsvc",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Sensor Service",name="sensorservice",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Server",name="lanmanserver",process_id="2924",run_as="LocalSystem"} 1
+windows_service_info{display_name="Shared PC Account Manager",name="shpamsvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Shell Hardware Detection",name="shellhwdetection",process_id="2444",run_as="LocalSystem"} 1
+windows_service_info{display_name="Smart Card",name="scardsvr",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Smart Card Device Enumeration Service",name="scdeviceenum",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Smart Card Removal Policy",name="scpolicysvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Software Protection",name="sppsvc",process_id="0",run_as="NT AUTHORITY\\NetworkService"} 1
+windows_service_info{display_name="Spatial Data Service",name="sharedrealitysvc",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Spot Verifier",name="svsvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="State Repository Service",name="staterepository",process_id="2420",run_as="LocalSystem"} 1
+windows_service_info{display_name="Still Image Acquisition Events",name="wiarpc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Storage Service",name="storsvc",process_id="6576",run_as="LocalSystem"} 1
+windows_service_info{display_name="Storage Tiers Management",name="tieringengineservice",process_id="0",run_as="localSystem"} 1
+windows_service_info{display_name="Sync Host_390e7",name="onesyncsvc_390e7",process_id="2268",run_as=""} 1
+windows_service_info{display_name="SysMain",name="sysmain",process_id="1908",run_as="LocalSystem"} 1
+windows_service_info{display_name="System Event Notification Service",name="sens",process_id="1892",run_as="LocalSystem"} 1
+windows_service_info{display_name="System Events Broker",name="systemeventsbroker",process_id="884",run_as="LocalSystem"} 1
+windows_service_info{display_name="System Guard Runtime Monitor Broker",name="sgrmbroker",process_id="5904",run_as="LocalSystem"} 1
+windows_service_info{display_name="TCP/IP NetBIOS Helper",name="lmhosts",process_id="3964",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Task Scheduler",name="schedule",process_id="1148",run_as="LocalSystem"} 1
+windows_service_info{display_name="Te.Service",name="te.service",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Telephony",name="tapisrv",process_id="0",run_as="NT AUTHORITY\\NetworkService"} 1
+windows_service_info{display_name="Themes",name="themes",process_id="1944",run_as="LocalSystem"} 1
+windows_service_info{display_name="Time Broker",name="timebrokersvc",process_id="1244",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Touch Keyboard and Handwriting Panel Service",name="tabletinputservice",process_id="4284",run_as="LocalSystem"} 1
+windows_service_info{display_name="UPnP Device Host",name="upnphost",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Update Orchestrator Service",name="usosvc",process_id="272",run_as="LocalSystem"} 1
+windows_service_info{display_name="User Data Access_390e7",name="userdatasvc_390e7",process_id="0",run_as=""} 1
+windows_service_info{display_name="User Data Storage_390e7",name="unistoresvc_390e7",process_id="0",run_as=""} 1
+windows_service_info{display_name="User Experience Virtualization Service",name="uevagentservice",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="User Manager",name="usermanager",process_id="1440",run_as="LocalSystem"} 1
+windows_service_info{display_name="User Profile Service",name="profsvc",process_id="1228",run_as="LocalSystem"} 1
+windows_service_info{display_name="Virtual Disk",name="vds",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="VirtualBox Guest Additions Service",name="vboxservice",process_id="1792",run_as="LocalSystem"} 1
+windows_service_info{display_name="Volume Shadow Copy",name="vss",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Volumetric Audio Compositor Service",name="vacsvc",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="WLAN AutoConfig",name="wlansvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="WMI Performance Adapter",name="wmiapsrv",process_id="0",run_as="localSystem"} 1
+windows_service_info{display_name="WWAN AutoConfig",name="wwansvc",process_id="0",run_as="localSystem"} 1
+windows_service_info{display_name="WalletService",name="walletservice",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="WarpJITSvc",name="warpjitsvc",process_id="0",run_as="NT Authority\\LocalService"} 1
+windows_service_info{display_name="Web Account Manager",name="tokenbroker",process_id="4204",run_as="LocalSystem"} 1
+windows_service_info{display_name="WebClient",name="webclient",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Wi-Fi Direct Services Connection Manager Service",name="wfdsconmgrsvc",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="WinHTTP Web Proxy Auto-Discovery Service",name="winhttpautoproxysvc",process_id="2176",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Windows Audio",name="audiosrv",process_id="2288",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Windows Audio Endpoint Builder",name="audioendpointbuilder",process_id="2100",run_as="LocalSystem"} 1
+windows_service_info{display_name="Windows Backup",name="sdrsvc",process_id="0",run_as="localSystem"} 1
+windows_service_info{display_name="Windows Biometric Service",name="wbiosrvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Windows Camera Frame Server",name="frameserver",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Windows Connect Now - Config Registrar",name="wcncsvc",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Windows Connection Manager",name="wcmsvc",process_id="2372",run_as="NT Authority\\LocalService"} 1
+windows_service_info{display_name="Windows Defender Advanced Threat Protection Service",name="sense",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Windows Defender Antivirus Network Inspection Service",name="wdnissvc",process_id="2976",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Windows Defender Antivirus Service",name="windefend",process_id="2956",run_as="LocalSystem"} 1
+windows_service_info{display_name="Windows Defender Firewall",name="mpssvc",process_id="2668",run_as="NT Authority\\LocalService"} 1
+windows_service_info{display_name="Windows Encryption Provider Host Service",name="wephostsvc",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Windows Error Reporting Service",name="wersvc",process_id="0",run_as="localSystem"} 1
+windows_service_info{display_name="Windows Event Collector",name="wecsvc",process_id="0",run_as="NT AUTHORITY\\NetworkService"} 1
+windows_service_info{display_name="Windows Event Log",name="eventlog",process_id="1196",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Windows Font Cache Service",name="fontcache",process_id="2108",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Windows Image Acquisition (WIA)",name="stisvc",process_id="0",run_as="NT Authority\\LocalService"} 1
+windows_service_info{display_name="Windows Insider Service",name="wisvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Windows Installer",name="msiserver",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Windows License Manager Service",name="licensemanager",process_id="1288",run_as="NT Authority\\LocalService"} 1
+windows_service_info{display_name="Windows Licensing Monitoring Service",name="wlms",process_id="2968",run_as="LocalSystem"} 1
+windows_service_info{display_name="Windows Management Instrumentation",name="winmgmt",process_id="2856",run_as="localSystem"} 1
+windows_service_info{display_name="Windows Management Service",name="wmansvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Windows Media Player Network Sharing Service",name="wmpnetworksvc",process_id="0",run_as="NT AUTHORITY\\NetworkService"} 1
+windows_service_info{display_name="Windows Mixed Reality OpenXR Service",name="mixedrealityopenxrsvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Windows Mobile Hotspot Service",name="icssvc",process_id="0",run_as="NT Authority\\LocalService"} 1
+windows_service_info{display_name="Windows Modules Installer",name="trustedinstaller",process_id="0",run_as="localSystem"} 1
+windows_service_info{display_name="Windows Perception Service",name="spectrum",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Windows Perception Simulation Service",name="perceptionsimulation",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Windows Phone IP over USB Transport (IpOverUsbSvc)",name="ipoverusbsvc",process_id="2864",run_as="LocalSystem"} 1
+windows_service_info{display_name="Windows Presentation Foundation Font Cache 3.0.0.0",name="fontcache3.0.0.0",process_id="0",run_as="NT Authority\\LocalService"} 1
+windows_service_info{display_name="Windows Push Notifications System Service",name="wpnservice",process_id="2992",run_as="LocalSystem"} 1
+windows_service_info{display_name="Windows Push Notifications User Service_390e7",name="wpnuserservice_390e7",process_id="3496",run_as=""} 1
+windows_service_info{display_name="Windows PushToInstall Service",name="pushtoinstall",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Windows Remote Management (WS-Management)",name="winrm",process_id="0",run_as="NT AUTHORITY\\NetworkService"} 1
+windows_service_info{display_name="Windows Search",name="wsearch",process_id="5624",run_as="LocalSystem"} 1
+windows_service_info{display_name="Windows Security Service",name="securityhealthservice",process_id="1280",run_as="LocalSystem"} 1
+windows_service_info{display_name="Windows Time",name="w32time",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Windows Update",name="wuauserv",process_id="1820",run_as="LocalSystem"} 1
+windows_service_info{display_name="Windows Update Medic Service",name="waasmedicsvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Wired AutoConfig",name="dot3svc",process_id="0",run_as="localSystem"} 1
+windows_service_info{display_name="Work Folders",name="workfolderssvc",process_id="0",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{display_name="Workstation",name="lanmanworkstation",process_id="2700",run_as="NT AUTHORITY\\NetworkService"} 1
+windows_service_info{display_name="Xbox Accessory Management Service",name="xboxgipsvc",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Xbox Live Auth Manager",name="xblauthmanager",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Xbox Live Game Save",name="xblgamesave",process_id="0",run_as="LocalSystem"} 1
+windows_service_info{display_name="Xbox Live Networking Service",name="xboxnetapisvc",process_id="0",run_as="LocalSystem"} 1
 # HELP windows_service_start_mode The start mode of the service (StartMode)
 # TYPE windows_service_start_mode gauge
+windows_service_start_mode{name="aarsvc_390e7",start_mode="auto"} 0
+windows_service_start_mode{name="aarsvc_390e7",start_mode="boot"} 0
+windows_service_start_mode{name="aarsvc_390e7",start_mode="disabled"} 0
+windows_service_start_mode{name="aarsvc_390e7",start_mode="manual"} 1
+windows_service_start_mode{name="aarsvc_390e7",start_mode="system"} 0
 windows_service_start_mode{name="ajrouter",start_mode="auto"} 0
 windows_service_start_mode{name="ajrouter",start_mode="boot"} 0
 windows_service_start_mode{name="ajrouter",start_mode="disabled"} 0
@@ -327,11 +391,6 @@ windows_service_start_mode{name="alg",start_mode="boot"} 0
 windows_service_start_mode{name="alg",start_mode="disabled"} 0
 windows_service_start_mode{name="alg",start_mode="manual"} 1
 windows_service_start_mode{name="alg",start_mode="system"} 0
-windows_service_start_mode{name="apphostsvc",start_mode="auto"} 1
-windows_service_start_mode{name="apphostsvc",start_mode="boot"} 0
-windows_service_start_mode{name="apphostsvc",start_mode="disabled"} 0
-windows_service_start_mode{name="apphostsvc",start_mode="manual"} 0
-windows_service_start_mode{name="apphostsvc",start_mode="system"} 0
 windows_service_start_mode{name="appidsvc",start_mode="auto"} 0
 windows_service_start_mode{name="appidsvc",start_mode="boot"} 0
 windows_service_start_mode{name="appidsvc",start_mode="disabled"} 0
@@ -362,56 +421,101 @@ windows_service_start_mode{name="appxsvc",start_mode="boot"} 0
 windows_service_start_mode{name="appxsvc",start_mode="disabled"} 0
 windows_service_start_mode{name="appxsvc",start_mode="manual"} 1
 windows_service_start_mode{name="appxsvc",start_mode="system"} 0
-windows_service_start_mode{name="audioendpointbuilder",start_mode="auto"} 0
+windows_service_start_mode{name="assignedaccessmanagersvc",start_mode="auto"} 0
+windows_service_start_mode{name="assignedaccessmanagersvc",start_mode="boot"} 0
+windows_service_start_mode{name="assignedaccessmanagersvc",start_mode="disabled"} 0
+windows_service_start_mode{name="assignedaccessmanagersvc",start_mode="manual"} 1
+windows_service_start_mode{name="assignedaccessmanagersvc",start_mode="system"} 0
+windows_service_start_mode{name="audioendpointbuilder",start_mode="auto"} 1
 windows_service_start_mode{name="audioendpointbuilder",start_mode="boot"} 0
 windows_service_start_mode{name="audioendpointbuilder",start_mode="disabled"} 0
-windows_service_start_mode{name="audioendpointbuilder",start_mode="manual"} 1
+windows_service_start_mode{name="audioendpointbuilder",start_mode="manual"} 0
 windows_service_start_mode{name="audioendpointbuilder",start_mode="system"} 0
-windows_service_start_mode{name="audiosrv",start_mode="auto"} 0
+windows_service_start_mode{name="audiosrv",start_mode="auto"} 1
 windows_service_start_mode{name="audiosrv",start_mode="boot"} 0
 windows_service_start_mode{name="audiosrv",start_mode="disabled"} 0
-windows_service_start_mode{name="audiosrv",start_mode="manual"} 1
+windows_service_start_mode{name="audiosrv",start_mode="manual"} 0
 windows_service_start_mode{name="audiosrv",start_mode="system"} 0
+windows_service_start_mode{name="autotimesvc",start_mode="auto"} 0
+windows_service_start_mode{name="autotimesvc",start_mode="boot"} 0
+windows_service_start_mode{name="autotimesvc",start_mode="disabled"} 0
+windows_service_start_mode{name="autotimesvc",start_mode="manual"} 1
+windows_service_start_mode{name="autotimesvc",start_mode="system"} 0
 windows_service_start_mode{name="axinstsv",start_mode="auto"} 0
 windows_service_start_mode{name="axinstsv",start_mode="boot"} 0
 windows_service_start_mode{name="axinstsv",start_mode="disabled"} 0
 windows_service_start_mode{name="axinstsv",start_mode="manual"} 1
 windows_service_start_mode{name="axinstsv",start_mode="system"} 0
+windows_service_start_mode{name="bcastdvruserservice_390e7",start_mode="auto"} 0
+windows_service_start_mode{name="bcastdvruserservice_390e7",start_mode="boot"} 0
+windows_service_start_mode{name="bcastdvruserservice_390e7",start_mode="disabled"} 0
+windows_service_start_mode{name="bcastdvruserservice_390e7",start_mode="manual"} 1
+windows_service_start_mode{name="bcastdvruserservice_390e7",start_mode="system"} 0
+windows_service_start_mode{name="bdesvc",start_mode="auto"} 0
+windows_service_start_mode{name="bdesvc",start_mode="boot"} 0
+windows_service_start_mode{name="bdesvc",start_mode="disabled"} 0
+windows_service_start_mode{name="bdesvc",start_mode="manual"} 1
+windows_service_start_mode{name="bdesvc",start_mode="system"} 0
 windows_service_start_mode{name="bfe",start_mode="auto"} 1
 windows_service_start_mode{name="bfe",start_mode="boot"} 0
 windows_service_start_mode{name="bfe",start_mode="disabled"} 0
 windows_service_start_mode{name="bfe",start_mode="manual"} 0
 windows_service_start_mode{name="bfe",start_mode="system"} 0
-windows_service_start_mode{name="bits",start_mode="auto"} 0
+windows_service_start_mode{name="bits",start_mode="auto"} 1
 windows_service_start_mode{name="bits",start_mode="boot"} 0
 windows_service_start_mode{name="bits",start_mode="disabled"} 0
-windows_service_start_mode{name="bits",start_mode="manual"} 1
+windows_service_start_mode{name="bits",start_mode="manual"} 0
 windows_service_start_mode{name="bits",start_mode="system"} 0
+windows_service_start_mode{name="bluetoothuserservice_390e7",start_mode="auto"} 0
+windows_service_start_mode{name="bluetoothuserservice_390e7",start_mode="boot"} 0
+windows_service_start_mode{name="bluetoothuserservice_390e7",start_mode="disabled"} 0
+windows_service_start_mode{name="bluetoothuserservice_390e7",start_mode="manual"} 1
+windows_service_start_mode{name="bluetoothuserservice_390e7",start_mode="system"} 0
 windows_service_start_mode{name="brokerinfrastructure",start_mode="auto"} 1
 windows_service_start_mode{name="brokerinfrastructure",start_mode="boot"} 0
 windows_service_start_mode{name="brokerinfrastructure",start_mode="disabled"} 0
 windows_service_start_mode{name="brokerinfrastructure",start_mode="manual"} 0
 windows_service_start_mode{name="brokerinfrastructure",start_mode="system"} 0
-windows_service_start_mode{name="browser",start_mode="auto"} 0
-windows_service_start_mode{name="browser",start_mode="boot"} 0
-windows_service_start_mode{name="browser",start_mode="disabled"} 1
-windows_service_start_mode{name="browser",start_mode="manual"} 0
-windows_service_start_mode{name="browser",start_mode="system"} 0
+windows_service_start_mode{name="btagservice",start_mode="auto"} 0
+windows_service_start_mode{name="btagservice",start_mode="boot"} 0
+windows_service_start_mode{name="btagservice",start_mode="disabled"} 0
+windows_service_start_mode{name="btagservice",start_mode="manual"} 1
+windows_service_start_mode{name="btagservice",start_mode="system"} 0
+windows_service_start_mode{name="bthavctpsvc",start_mode="auto"} 0
+windows_service_start_mode{name="bthavctpsvc",start_mode="boot"} 0
+windows_service_start_mode{name="bthavctpsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="bthavctpsvc",start_mode="manual"} 1
+windows_service_start_mode{name="bthavctpsvc",start_mode="system"} 0
 windows_service_start_mode{name="bthserv",start_mode="auto"} 0
 windows_service_start_mode{name="bthserv",start_mode="boot"} 0
 windows_service_start_mode{name="bthserv",start_mode="disabled"} 0
 windows_service_start_mode{name="bthserv",start_mode="manual"} 1
 windows_service_start_mode{name="bthserv",start_mode="system"} 0
+windows_service_start_mode{name="camsvc",start_mode="auto"} 0
+windows_service_start_mode{name="camsvc",start_mode="boot"} 0
+windows_service_start_mode{name="camsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="camsvc",start_mode="manual"} 1
+windows_service_start_mode{name="camsvc",start_mode="system"} 0
+windows_service_start_mode{name="captureservice_390e7",start_mode="auto"} 0
+windows_service_start_mode{name="captureservice_390e7",start_mode="boot"} 0
+windows_service_start_mode{name="captureservice_390e7",start_mode="disabled"} 0
+windows_service_start_mode{name="captureservice_390e7",start_mode="manual"} 1
+windows_service_start_mode{name="captureservice_390e7",start_mode="system"} 0
+windows_service_start_mode{name="cbdhsvc_390e7",start_mode="auto"} 0
+windows_service_start_mode{name="cbdhsvc_390e7",start_mode="boot"} 0
+windows_service_start_mode{name="cbdhsvc_390e7",start_mode="disabled"} 0
+windows_service_start_mode{name="cbdhsvc_390e7",start_mode="manual"} 1
+windows_service_start_mode{name="cbdhsvc_390e7",start_mode="system"} 0
 windows_service_start_mode{name="cdpsvc",start_mode="auto"} 1
 windows_service_start_mode{name="cdpsvc",start_mode="boot"} 0
 windows_service_start_mode{name="cdpsvc",start_mode="disabled"} 0
 windows_service_start_mode{name="cdpsvc",start_mode="manual"} 0
 windows_service_start_mode{name="cdpsvc",start_mode="system"} 0
-windows_service_start_mode{name="cdpusersvc_225e3",start_mode="auto"} 1
-windows_service_start_mode{name="cdpusersvc_225e3",start_mode="boot"} 0
-windows_service_start_mode{name="cdpusersvc_225e3",start_mode="disabled"} 0
-windows_service_start_mode{name="cdpusersvc_225e3",start_mode="manual"} 0
-windows_service_start_mode{name="cdpusersvc_225e3",start_mode="system"} 0
+windows_service_start_mode{name="cdpusersvc_390e7",start_mode="auto"} 1
+windows_service_start_mode{name="cdpusersvc_390e7",start_mode="boot"} 0
+windows_service_start_mode{name="cdpusersvc_390e7",start_mode="disabled"} 0
+windows_service_start_mode{name="cdpusersvc_390e7",start_mode="manual"} 0
+windows_service_start_mode{name="cdpusersvc_390e7",start_mode="system"} 0
 windows_service_start_mode{name="certpropsvc",start_mode="auto"} 0
 windows_service_start_mode{name="certpropsvc",start_mode="boot"} 0
 windows_service_start_mode{name="certpropsvc",start_mode="disabled"} 0
@@ -427,11 +531,21 @@ windows_service_start_mode{name="comsysapp",start_mode="boot"} 0
 windows_service_start_mode{name="comsysapp",start_mode="disabled"} 0
 windows_service_start_mode{name="comsysapp",start_mode="manual"} 1
 windows_service_start_mode{name="comsysapp",start_mode="system"} 0
+windows_service_start_mode{name="consentuxusersvc_390e7",start_mode="auto"} 0
+windows_service_start_mode{name="consentuxusersvc_390e7",start_mode="boot"} 0
+windows_service_start_mode{name="consentuxusersvc_390e7",start_mode="disabled"} 0
+windows_service_start_mode{name="consentuxusersvc_390e7",start_mode="manual"} 1
+windows_service_start_mode{name="consentuxusersvc_390e7",start_mode="system"} 0
 windows_service_start_mode{name="coremessagingregistrar",start_mode="auto"} 1
 windows_service_start_mode{name="coremessagingregistrar",start_mode="boot"} 0
 windows_service_start_mode{name="coremessagingregistrar",start_mode="disabled"} 0
 windows_service_start_mode{name="coremessagingregistrar",start_mode="manual"} 0
 windows_service_start_mode{name="coremessagingregistrar",start_mode="system"} 0
+windows_service_start_mode{name="credentialenrollmentmanagerusersvc_390e7",start_mode="auto"} 0
+windows_service_start_mode{name="credentialenrollmentmanagerusersvc_390e7",start_mode="boot"} 0
+windows_service_start_mode{name="credentialenrollmentmanagerusersvc_390e7",start_mode="disabled"} 0
+windows_service_start_mode{name="credentialenrollmentmanagerusersvc_390e7",start_mode="manual"} 1
+windows_service_start_mode{name="credentialenrollmentmanagerusersvc_390e7",start_mode="system"} 0
 windows_service_start_mode{name="cryptsvc",start_mode="auto"} 1
 windows_service_start_mode{name="cryptsvc",start_mode="boot"} 0
 windows_service_start_mode{name="cryptsvc",start_mode="disabled"} 0
@@ -439,24 +553,24 @@ windows_service_start_mode{name="cryptsvc",start_mode="manual"} 0
 windows_service_start_mode{name="cryptsvc",start_mode="system"} 0
 windows_service_start_mode{name="cscservice",start_mode="auto"} 0
 windows_service_start_mode{name="cscservice",start_mode="boot"} 0
-windows_service_start_mode{name="cscservice",start_mode="disabled"} 1
-windows_service_start_mode{name="cscservice",start_mode="manual"} 0
+windows_service_start_mode{name="cscservice",start_mode="disabled"} 0
+windows_service_start_mode{name="cscservice",start_mode="manual"} 1
 windows_service_start_mode{name="cscservice",start_mode="system"} 0
 windows_service_start_mode{name="dcomlaunch",start_mode="auto"} 1
 windows_service_start_mode{name="dcomlaunch",start_mode="boot"} 0
 windows_service_start_mode{name="dcomlaunch",start_mode="disabled"} 0
 windows_service_start_mode{name="dcomlaunch",start_mode="manual"} 0
 windows_service_start_mode{name="dcomlaunch",start_mode="system"} 0
-windows_service_start_mode{name="dcpsvc",start_mode="auto"} 0
-windows_service_start_mode{name="dcpsvc",start_mode="boot"} 0
-windows_service_start_mode{name="dcpsvc",start_mode="disabled"} 0
-windows_service_start_mode{name="dcpsvc",start_mode="manual"} 1
-windows_service_start_mode{name="dcpsvc",start_mode="system"} 0
 windows_service_start_mode{name="defragsvc",start_mode="auto"} 0
 windows_service_start_mode{name="defragsvc",start_mode="boot"} 0
 windows_service_start_mode{name="defragsvc",start_mode="disabled"} 0
 windows_service_start_mode{name="defragsvc",start_mode="manual"} 1
 windows_service_start_mode{name="defragsvc",start_mode="system"} 0
+windows_service_start_mode{name="deviceassociationbrokersvc_390e7",start_mode="auto"} 0
+windows_service_start_mode{name="deviceassociationbrokersvc_390e7",start_mode="boot"} 0
+windows_service_start_mode{name="deviceassociationbrokersvc_390e7",start_mode="disabled"} 0
+windows_service_start_mode{name="deviceassociationbrokersvc_390e7",start_mode="manual"} 1
+windows_service_start_mode{name="deviceassociationbrokersvc_390e7",start_mode="system"} 0
 windows_service_start_mode{name="deviceassociationservice",start_mode="auto"} 0
 windows_service_start_mode{name="deviceassociationservice",start_mode="boot"} 0
 windows_service_start_mode{name="deviceassociationservice",start_mode="disabled"} 0
@@ -467,6 +581,16 @@ windows_service_start_mode{name="deviceinstall",start_mode="boot"} 0
 windows_service_start_mode{name="deviceinstall",start_mode="disabled"} 0
 windows_service_start_mode{name="deviceinstall",start_mode="manual"} 1
 windows_service_start_mode{name="deviceinstall",start_mode="system"} 0
+windows_service_start_mode{name="devicepickerusersvc_390e7",start_mode="auto"} 0
+windows_service_start_mode{name="devicepickerusersvc_390e7",start_mode="boot"} 0
+windows_service_start_mode{name="devicepickerusersvc_390e7",start_mode="disabled"} 0
+windows_service_start_mode{name="devicepickerusersvc_390e7",start_mode="manual"} 1
+windows_service_start_mode{name="devicepickerusersvc_390e7",start_mode="system"} 0
+windows_service_start_mode{name="devicesflowusersvc_390e7",start_mode="auto"} 0
+windows_service_start_mode{name="devicesflowusersvc_390e7",start_mode="boot"} 0
+windows_service_start_mode{name="devicesflowusersvc_390e7",start_mode="disabled"} 0
+windows_service_start_mode{name="devicesflowusersvc_390e7",start_mode="manual"} 1
+windows_service_start_mode{name="devicesflowusersvc_390e7",start_mode="system"} 0
 windows_service_start_mode{name="devquerybroker",start_mode="auto"} 0
 windows_service_start_mode{name="devquerybroker",start_mode="boot"} 0
 windows_service_start_mode{name="devquerybroker",start_mode="disabled"} 0
@@ -482,11 +606,26 @@ windows_service_start_mode{name="diagnosticshub.standardcollector.service",start
 windows_service_start_mode{name="diagnosticshub.standardcollector.service",start_mode="disabled"} 0
 windows_service_start_mode{name="diagnosticshub.standardcollector.service",start_mode="manual"} 1
 windows_service_start_mode{name="diagnosticshub.standardcollector.service",start_mode="system"} 0
+windows_service_start_mode{name="diagsvc",start_mode="auto"} 0
+windows_service_start_mode{name="diagsvc",start_mode="boot"} 0
+windows_service_start_mode{name="diagsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="diagsvc",start_mode="manual"} 1
+windows_service_start_mode{name="diagsvc",start_mode="system"} 0
 windows_service_start_mode{name="diagtrack",start_mode="auto"} 1
 windows_service_start_mode{name="diagtrack",start_mode="boot"} 0
 windows_service_start_mode{name="diagtrack",start_mode="disabled"} 0
 windows_service_start_mode{name="diagtrack",start_mode="manual"} 0
 windows_service_start_mode{name="diagtrack",start_mode="system"} 0
+windows_service_start_mode{name="dispbrokerdesktopsvc",start_mode="auto"} 1
+windows_service_start_mode{name="dispbrokerdesktopsvc",start_mode="boot"} 0
+windows_service_start_mode{name="dispbrokerdesktopsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="dispbrokerdesktopsvc",start_mode="manual"} 0
+windows_service_start_mode{name="dispbrokerdesktopsvc",start_mode="system"} 0
+windows_service_start_mode{name="displayenhancementservice",start_mode="auto"} 0
+windows_service_start_mode{name="displayenhancementservice",start_mode="boot"} 0
+windows_service_start_mode{name="displayenhancementservice",start_mode="disabled"} 0
+windows_service_start_mode{name="displayenhancementservice",start_mode="manual"} 1
+windows_service_start_mode{name="displayenhancementservice",start_mode="system"} 0
 windows_service_start_mode{name="dmenrollmentsvc",start_mode="auto"} 0
 windows_service_start_mode{name="dmenrollmentsvc",start_mode="boot"} 0
 windows_service_start_mode{name="dmenrollmentsvc",start_mode="disabled"} 0
@@ -502,6 +641,11 @@ windows_service_start_mode{name="dnscache",start_mode="boot"} 0
 windows_service_start_mode{name="dnscache",start_mode="disabled"} 0
 windows_service_start_mode{name="dnscache",start_mode="manual"} 0
 windows_service_start_mode{name="dnscache",start_mode="system"} 0
+windows_service_start_mode{name="dosvc",start_mode="auto"} 1
+windows_service_start_mode{name="dosvc",start_mode="boot"} 0
+windows_service_start_mode{name="dosvc",start_mode="disabled"} 0
+windows_service_start_mode{name="dosvc",start_mode="manual"} 0
+windows_service_start_mode{name="dosvc",start_mode="system"} 0
 windows_service_start_mode{name="dot3svc",start_mode="auto"} 0
 windows_service_start_mode{name="dot3svc",start_mode="boot"} 0
 windows_service_start_mode{name="dot3svc",start_mode="disabled"} 0
@@ -522,6 +666,11 @@ windows_service_start_mode{name="dssvc",start_mode="boot"} 0
 windows_service_start_mode{name="dssvc",start_mode="disabled"} 0
 windows_service_start_mode{name="dssvc",start_mode="manual"} 1
 windows_service_start_mode{name="dssvc",start_mode="system"} 0
+windows_service_start_mode{name="dusmsvc",start_mode="auto"} 1
+windows_service_start_mode{name="dusmsvc",start_mode="boot"} 0
+windows_service_start_mode{name="dusmsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="dusmsvc",start_mode="manual"} 0
+windows_service_start_mode{name="dusmsvc",start_mode="system"} 0
 windows_service_start_mode{name="eaphost",start_mode="auto"} 0
 windows_service_start_mode{name="eaphost",start_mode="boot"} 0
 windows_service_start_mode{name="eaphost",start_mode="disabled"} 0
@@ -552,6 +701,11 @@ windows_service_start_mode{name="eventsystem",start_mode="boot"} 0
 windows_service_start_mode{name="eventsystem",start_mode="disabled"} 0
 windows_service_start_mode{name="eventsystem",start_mode="manual"} 0
 windows_service_start_mode{name="eventsystem",start_mode="system"} 0
+windows_service_start_mode{name="fax",start_mode="auto"} 0
+windows_service_start_mode{name="fax",start_mode="boot"} 0
+windows_service_start_mode{name="fax",start_mode="disabled"} 0
+windows_service_start_mode{name="fax",start_mode="manual"} 1
+windows_service_start_mode{name="fax",start_mode="system"} 0
 windows_service_start_mode{name="fdphost",start_mode="auto"} 0
 windows_service_start_mode{name="fdphost",start_mode="boot"} 0
 windows_service_start_mode{name="fdphost",start_mode="disabled"} 0
@@ -562,11 +716,21 @@ windows_service_start_mode{name="fdrespub",start_mode="boot"} 0
 windows_service_start_mode{name="fdrespub",start_mode="disabled"} 0
 windows_service_start_mode{name="fdrespub",start_mode="manual"} 1
 windows_service_start_mode{name="fdrespub",start_mode="system"} 0
+windows_service_start_mode{name="fhsvc",start_mode="auto"} 0
+windows_service_start_mode{name="fhsvc",start_mode="boot"} 0
+windows_service_start_mode{name="fhsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="fhsvc",start_mode="manual"} 1
+windows_service_start_mode{name="fhsvc",start_mode="system"} 0
 windows_service_start_mode{name="fontcache",start_mode="auto"} 1
 windows_service_start_mode{name="fontcache",start_mode="boot"} 0
 windows_service_start_mode{name="fontcache",start_mode="disabled"} 0
 windows_service_start_mode{name="fontcache",start_mode="manual"} 0
 windows_service_start_mode{name="fontcache",start_mode="system"} 0
+windows_service_start_mode{name="fontcache3.0.0.0",start_mode="auto"} 0
+windows_service_start_mode{name="fontcache3.0.0.0",start_mode="boot"} 0
+windows_service_start_mode{name="fontcache3.0.0.0",start_mode="disabled"} 0
+windows_service_start_mode{name="fontcache3.0.0.0",start_mode="manual"} 1
+windows_service_start_mode{name="fontcache3.0.0.0",start_mode="system"} 0
 windows_service_start_mode{name="frameserver",start_mode="auto"} 0
 windows_service_start_mode{name="frameserver",start_mode="boot"} 0
 windows_service_start_mode{name="frameserver",start_mode="disabled"} 0
@@ -577,6 +741,11 @@ windows_service_start_mode{name="gpsvc",start_mode="boot"} 0
 windows_service_start_mode{name="gpsvc",start_mode="disabled"} 0
 windows_service_start_mode{name="gpsvc",start_mode="manual"} 0
 windows_service_start_mode{name="gpsvc",start_mode="system"} 0
+windows_service_start_mode{name="graphicsperfsvc",start_mode="auto"} 0
+windows_service_start_mode{name="graphicsperfsvc",start_mode="boot"} 0
+windows_service_start_mode{name="graphicsperfsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="graphicsperfsvc",start_mode="manual"} 1
+windows_service_start_mode{name="graphicsperfsvc",start_mode="system"} 0
 windows_service_start_mode{name="hidserv",start_mode="auto"} 0
 windows_service_start_mode{name="hidserv",start_mode="boot"} 0
 windows_service_start_mode{name="hidserv",start_mode="disabled"} 0
@@ -592,26 +761,36 @@ windows_service_start_mode{name="icssvc",start_mode="boot"} 0
 windows_service_start_mode{name="icssvc",start_mode="disabled"} 0
 windows_service_start_mode{name="icssvc",start_mode="manual"} 1
 windows_service_start_mode{name="icssvc",start_mode="system"} 0
-windows_service_start_mode{name="ikeext",start_mode="auto"} 1
+windows_service_start_mode{name="ikeext",start_mode="auto"} 0
 windows_service_start_mode{name="ikeext",start_mode="boot"} 0
 windows_service_start_mode{name="ikeext",start_mode="disabled"} 0
-windows_service_start_mode{name="ikeext",start_mode="manual"} 0
+windows_service_start_mode{name="ikeext",start_mode="manual"} 1
 windows_service_start_mode{name="ikeext",start_mode="system"} 0
+windows_service_start_mode{name="installservice",start_mode="auto"} 0
+windows_service_start_mode{name="installservice",start_mode="boot"} 0
+windows_service_start_mode{name="installservice",start_mode="disabled"} 0
+windows_service_start_mode{name="installservice",start_mode="manual"} 1
+windows_service_start_mode{name="installservice",start_mode="system"} 0
 windows_service_start_mode{name="iphlpsvc",start_mode="auto"} 1
 windows_service_start_mode{name="iphlpsvc",start_mode="boot"} 0
 windows_service_start_mode{name="iphlpsvc",start_mode="disabled"} 0
 windows_service_start_mode{name="iphlpsvc",start_mode="manual"} 0
 windows_service_start_mode{name="iphlpsvc",start_mode="system"} 0
+windows_service_start_mode{name="ipoverusbsvc",start_mode="auto"} 1
+windows_service_start_mode{name="ipoverusbsvc",start_mode="boot"} 0
+windows_service_start_mode{name="ipoverusbsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="ipoverusbsvc",start_mode="manual"} 0
+windows_service_start_mode{name="ipoverusbsvc",start_mode="system"} 0
+windows_service_start_mode{name="ipxlatcfgsvc",start_mode="auto"} 0
+windows_service_start_mode{name="ipxlatcfgsvc",start_mode="boot"} 0
+windows_service_start_mode{name="ipxlatcfgsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="ipxlatcfgsvc",start_mode="manual"} 1
+windows_service_start_mode{name="ipxlatcfgsvc",start_mode="system"} 0
 windows_service_start_mode{name="keyiso",start_mode="auto"} 0
 windows_service_start_mode{name="keyiso",start_mode="boot"} 0
 windows_service_start_mode{name="keyiso",start_mode="disabled"} 0
 windows_service_start_mode{name="keyiso",start_mode="manual"} 1
 windows_service_start_mode{name="keyiso",start_mode="system"} 0
-windows_service_start_mode{name="kpssvc",start_mode="auto"} 0
-windows_service_start_mode{name="kpssvc",start_mode="boot"} 0
-windows_service_start_mode{name="kpssvc",start_mode="disabled"} 0
-windows_service_start_mode{name="kpssvc",start_mode="manual"} 1
-windows_service_start_mode{name="kpssvc",start_mode="system"} 0
 windows_service_start_mode{name="ktmrm",start_mode="auto"} 0
 windows_service_start_mode{name="ktmrm",start_mode="boot"} 0
 windows_service_start_mode{name="ktmrm",start_mode="disabled"} 0
@@ -647,25 +826,45 @@ windows_service_start_mode{name="lmhosts",start_mode="boot"} 0
 windows_service_start_mode{name="lmhosts",start_mode="disabled"} 0
 windows_service_start_mode{name="lmhosts",start_mode="manual"} 1
 windows_service_start_mode{name="lmhosts",start_mode="system"} 0
-windows_service_start_mode{name="lsm",start_mode="auto"} 1
+windows_service_start_mode{name="lsm",start_mode="auto"} 0
 windows_service_start_mode{name="lsm",start_mode="boot"} 0
 windows_service_start_mode{name="lsm",start_mode="disabled"} 0
 windows_service_start_mode{name="lsm",start_mode="manual"} 0
 windows_service_start_mode{name="lsm",start_mode="system"} 0
+windows_service_start_mode{name="lxpsvc",start_mode="auto"} 0
+windows_service_start_mode{name="lxpsvc",start_mode="boot"} 0
+windows_service_start_mode{name="lxpsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="lxpsvc",start_mode="manual"} 1
+windows_service_start_mode{name="lxpsvc",start_mode="system"} 0
 windows_service_start_mode{name="mapsbroker",start_mode="auto"} 1
 windows_service_start_mode{name="mapsbroker",start_mode="boot"} 0
 windows_service_start_mode{name="mapsbroker",start_mode="disabled"} 0
 windows_service_start_mode{name="mapsbroker",start_mode="manual"} 0
 windows_service_start_mode{name="mapsbroker",start_mode="system"} 0
+windows_service_start_mode{name="messagingservice_390e7",start_mode="auto"} 0
+windows_service_start_mode{name="messagingservice_390e7",start_mode="boot"} 0
+windows_service_start_mode{name="messagingservice_390e7",start_mode="disabled"} 0
+windows_service_start_mode{name="messagingservice_390e7",start_mode="manual"} 1
+windows_service_start_mode{name="messagingservice_390e7",start_mode="system"} 0
+windows_service_start_mode{name="mixedrealityopenxrsvc",start_mode="auto"} 0
+windows_service_start_mode{name="mixedrealityopenxrsvc",start_mode="boot"} 0
+windows_service_start_mode{name="mixedrealityopenxrsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="mixedrealityopenxrsvc",start_mode="manual"} 1
+windows_service_start_mode{name="mixedrealityopenxrsvc",start_mode="system"} 0
+windows_service_start_mode{name="mozillamaintenance",start_mode="auto"} 0
+windows_service_start_mode{name="mozillamaintenance",start_mode="boot"} 0
+windows_service_start_mode{name="mozillamaintenance",start_mode="disabled"} 0
+windows_service_start_mode{name="mozillamaintenance",start_mode="manual"} 1
+windows_service_start_mode{name="mozillamaintenance",start_mode="system"} 0
 windows_service_start_mode{name="mpssvc",start_mode="auto"} 1
 windows_service_start_mode{name="mpssvc",start_mode="boot"} 0
 windows_service_start_mode{name="mpssvc",start_mode="disabled"} 0
 windows_service_start_mode{name="mpssvc",start_mode="manual"} 0
 windows_service_start_mode{name="mpssvc",start_mode="system"} 0
-windows_service_start_mode{name="msdtc",start_mode="auto"} 1
+windows_service_start_mode{name="msdtc",start_mode="auto"} 0
 windows_service_start_mode{name="msdtc",start_mode="boot"} 0
 windows_service_start_mode{name="msdtc",start_mode="disabled"} 0
-windows_service_start_mode{name="msdtc",start_mode="manual"} 0
+windows_service_start_mode{name="msdtc",start_mode="manual"} 1
 windows_service_start_mode{name="msdtc",start_mode="system"} 0
 windows_service_start_mode{name="msiscsi",start_mode="auto"} 0
 windows_service_start_mode{name="msiscsi",start_mode="boot"} 0
@@ -677,6 +876,11 @@ windows_service_start_mode{name="msiserver",start_mode="boot"} 0
 windows_service_start_mode{name="msiserver",start_mode="disabled"} 0
 windows_service_start_mode{name="msiserver",start_mode="manual"} 1
 windows_service_start_mode{name="msiserver",start_mode="system"} 0
+windows_service_start_mode{name="naturalauthentication",start_mode="auto"} 0
+windows_service_start_mode{name="naturalauthentication",start_mode="boot"} 0
+windows_service_start_mode{name="naturalauthentication",start_mode="disabled"} 0
+windows_service_start_mode{name="naturalauthentication",start_mode="manual"} 1
+windows_service_start_mode{name="naturalauthentication",start_mode="system"} 0
 windows_service_start_mode{name="ncasvc",start_mode="auto"} 0
 windows_service_start_mode{name="ncasvc",start_mode="boot"} 0
 windows_service_start_mode{name="ncasvc",start_mode="disabled"} 0
@@ -687,6 +891,11 @@ windows_service_start_mode{name="ncbservice",start_mode="boot"} 0
 windows_service_start_mode{name="ncbservice",start_mode="disabled"} 0
 windows_service_start_mode{name="ncbservice",start_mode="manual"} 1
 windows_service_start_mode{name="ncbservice",start_mode="system"} 0
+windows_service_start_mode{name="ncdautosetup",start_mode="auto"} 0
+windows_service_start_mode{name="ncdautosetup",start_mode="boot"} 0
+windows_service_start_mode{name="ncdautosetup",start_mode="disabled"} 0
+windows_service_start_mode{name="ncdautosetup",start_mode="manual"} 1
+windows_service_start_mode{name="ncdautosetup",start_mode="system"} 0
 windows_service_start_mode{name="netlogon",start_mode="auto"} 0
 windows_service_start_mode{name="netlogon",start_mode="boot"} 0
 windows_service_start_mode{name="netlogon",start_mode="disabled"} 0
@@ -705,7 +914,7 @@ windows_service_start_mode{name="netprofm",start_mode="system"} 0
 windows_service_start_mode{name="netsetupsvc",start_mode="auto"} 0
 windows_service_start_mode{name="netsetupsvc",start_mode="boot"} 0
 windows_service_start_mode{name="netsetupsvc",start_mode="disabled"} 0
-windows_service_start_mode{name="netsetupsvc",start_mode="manual"} 1
+windows_service_start_mode{name="netsetupsvc",start_mode="manual"} 0
 windows_service_start_mode{name="netsetupsvc",start_mode="system"} 0
 windows_service_start_mode{name="nettcpportsharing",start_mode="auto"} 0
 windows_service_start_mode{name="nettcpportsharing",start_mode="boot"} 0
@@ -737,16 +946,36 @@ windows_service_start_mode{name="nsi",start_mode="boot"} 0
 windows_service_start_mode{name="nsi",start_mode="disabled"} 0
 windows_service_start_mode{name="nsi",start_mode="manual"} 0
 windows_service_start_mode{name="nsi",start_mode="system"} 0
-windows_service_start_mode{name="onesyncsvc_225e3",start_mode="auto"} 1
-windows_service_start_mode{name="onesyncsvc_225e3",start_mode="boot"} 0
-windows_service_start_mode{name="onesyncsvc_225e3",start_mode="disabled"} 0
-windows_service_start_mode{name="onesyncsvc_225e3",start_mode="manual"} 0
-windows_service_start_mode{name="onesyncsvc_225e3",start_mode="system"} 0
-windows_service_start_mode{name="pcasvc",start_mode="auto"} 1
+windows_service_start_mode{name="onesyncsvc_390e7",start_mode="auto"} 1
+windows_service_start_mode{name="onesyncsvc_390e7",start_mode="boot"} 0
+windows_service_start_mode{name="onesyncsvc_390e7",start_mode="disabled"} 0
+windows_service_start_mode{name="onesyncsvc_390e7",start_mode="manual"} 0
+windows_service_start_mode{name="onesyncsvc_390e7",start_mode="system"} 0
+windows_service_start_mode{name="p2pimsvc",start_mode="auto"} 0
+windows_service_start_mode{name="p2pimsvc",start_mode="boot"} 0
+windows_service_start_mode{name="p2pimsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="p2pimsvc",start_mode="manual"} 1
+windows_service_start_mode{name="p2pimsvc",start_mode="system"} 0
+windows_service_start_mode{name="p2psvc",start_mode="auto"} 0
+windows_service_start_mode{name="p2psvc",start_mode="boot"} 0
+windows_service_start_mode{name="p2psvc",start_mode="disabled"} 0
+windows_service_start_mode{name="p2psvc",start_mode="manual"} 1
+windows_service_start_mode{name="p2psvc",start_mode="system"} 0
+windows_service_start_mode{name="pcasvc",start_mode="auto"} 0
 windows_service_start_mode{name="pcasvc",start_mode="boot"} 0
 windows_service_start_mode{name="pcasvc",start_mode="disabled"} 0
-windows_service_start_mode{name="pcasvc",start_mode="manual"} 0
+windows_service_start_mode{name="pcasvc",start_mode="manual"} 1
 windows_service_start_mode{name="pcasvc",start_mode="system"} 0
+windows_service_start_mode{name="peerdistsvc",start_mode="auto"} 0
+windows_service_start_mode{name="peerdistsvc",start_mode="boot"} 0
+windows_service_start_mode{name="peerdistsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="peerdistsvc",start_mode="manual"} 1
+windows_service_start_mode{name="peerdistsvc",start_mode="system"} 0
+windows_service_start_mode{name="perceptionsimulation",start_mode="auto"} 0
+windows_service_start_mode{name="perceptionsimulation",start_mode="boot"} 0
+windows_service_start_mode{name="perceptionsimulation",start_mode="disabled"} 0
+windows_service_start_mode{name="perceptionsimulation",start_mode="manual"} 1
+windows_service_start_mode{name="perceptionsimulation",start_mode="system"} 0
 windows_service_start_mode{name="perfhost",start_mode="auto"} 0
 windows_service_start_mode{name="perfhost",start_mode="boot"} 0
 windows_service_start_mode{name="perfhost",start_mode="disabled"} 0
@@ -757,11 +986,11 @@ windows_service_start_mode{name="phonesvc",start_mode="boot"} 0
 windows_service_start_mode{name="phonesvc",start_mode="disabled"} 0
 windows_service_start_mode{name="phonesvc",start_mode="manual"} 1
 windows_service_start_mode{name="phonesvc",start_mode="system"} 0
-windows_service_start_mode{name="pimindexmaintenancesvc_225e3",start_mode="auto"} 0
-windows_service_start_mode{name="pimindexmaintenancesvc_225e3",start_mode="boot"} 0
-windows_service_start_mode{name="pimindexmaintenancesvc_225e3",start_mode="disabled"} 0
-windows_service_start_mode{name="pimindexmaintenancesvc_225e3",start_mode="manual"} 1
-windows_service_start_mode{name="pimindexmaintenancesvc_225e3",start_mode="system"} 0
+windows_service_start_mode{name="pimindexmaintenancesvc_390e7",start_mode="auto"} 0
+windows_service_start_mode{name="pimindexmaintenancesvc_390e7",start_mode="boot"} 0
+windows_service_start_mode{name="pimindexmaintenancesvc_390e7",start_mode="disabled"} 0
+windows_service_start_mode{name="pimindexmaintenancesvc_390e7",start_mode="manual"} 1
+windows_service_start_mode{name="pimindexmaintenancesvc_390e7",start_mode="system"} 0
 windows_service_start_mode{name="pla",start_mode="auto"} 0
 windows_service_start_mode{name="pla",start_mode="boot"} 0
 windows_service_start_mode{name="pla",start_mode="disabled"} 0
@@ -772,6 +1001,16 @@ windows_service_start_mode{name="plugplay",start_mode="boot"} 0
 windows_service_start_mode{name="plugplay",start_mode="disabled"} 0
 windows_service_start_mode{name="plugplay",start_mode="manual"} 1
 windows_service_start_mode{name="plugplay",start_mode="system"} 0
+windows_service_start_mode{name="pnrpautoreg",start_mode="auto"} 0
+windows_service_start_mode{name="pnrpautoreg",start_mode="boot"} 0
+windows_service_start_mode{name="pnrpautoreg",start_mode="disabled"} 0
+windows_service_start_mode{name="pnrpautoreg",start_mode="manual"} 1
+windows_service_start_mode{name="pnrpautoreg",start_mode="system"} 0
+windows_service_start_mode{name="pnrpsvc",start_mode="auto"} 0
+windows_service_start_mode{name="pnrpsvc",start_mode="boot"} 0
+windows_service_start_mode{name="pnrpsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="pnrpsvc",start_mode="manual"} 1
+windows_service_start_mode{name="pnrpsvc",start_mode="system"} 0
 windows_service_start_mode{name="policyagent",start_mode="auto"} 0
 windows_service_start_mode{name="policyagent",start_mode="boot"} 0
 windows_service_start_mode{name="policyagent",start_mode="disabled"} 0
@@ -787,11 +1026,21 @@ windows_service_start_mode{name="printnotify",start_mode="boot"} 0
 windows_service_start_mode{name="printnotify",start_mode="disabled"} 0
 windows_service_start_mode{name="printnotify",start_mode="manual"} 1
 windows_service_start_mode{name="printnotify",start_mode="system"} 0
+windows_service_start_mode{name="printworkflowusersvc_390e7",start_mode="auto"} 0
+windows_service_start_mode{name="printworkflowusersvc_390e7",start_mode="boot"} 0
+windows_service_start_mode{name="printworkflowusersvc_390e7",start_mode="disabled"} 0
+windows_service_start_mode{name="printworkflowusersvc_390e7",start_mode="manual"} 1
+windows_service_start_mode{name="printworkflowusersvc_390e7",start_mode="system"} 0
 windows_service_start_mode{name="profsvc",start_mode="auto"} 1
 windows_service_start_mode{name="profsvc",start_mode="boot"} 0
 windows_service_start_mode{name="profsvc",start_mode="disabled"} 0
 windows_service_start_mode{name="profsvc",start_mode="manual"} 0
 windows_service_start_mode{name="profsvc",start_mode="system"} 0
+windows_service_start_mode{name="pushtoinstall",start_mode="auto"} 0
+windows_service_start_mode{name="pushtoinstall",start_mode="boot"} 0
+windows_service_start_mode{name="pushtoinstall",start_mode="disabled"} 0
+windows_service_start_mode{name="pushtoinstall",start_mode="manual"} 1
+windows_service_start_mode{name="pushtoinstall",start_mode="system"} 0
 windows_service_start_mode{name="qwave",start_mode="auto"} 0
 windows_service_start_mode{name="qwave",start_mode="boot"} 0
 windows_service_start_mode{name="qwave",start_mode="disabled"} 0
@@ -812,11 +1061,16 @@ windows_service_start_mode{name="remoteaccess",start_mode="boot"} 0
 windows_service_start_mode{name="remoteaccess",start_mode="disabled"} 1
 windows_service_start_mode{name="remoteaccess",start_mode="manual"} 0
 windows_service_start_mode{name="remoteaccess",start_mode="system"} 0
-windows_service_start_mode{name="remoteregistry",start_mode="auto"} 1
+windows_service_start_mode{name="remoteregistry",start_mode="auto"} 0
 windows_service_start_mode{name="remoteregistry",start_mode="boot"} 0
-windows_service_start_mode{name="remoteregistry",start_mode="disabled"} 0
+windows_service_start_mode{name="remoteregistry",start_mode="disabled"} 1
 windows_service_start_mode{name="remoteregistry",start_mode="manual"} 0
 windows_service_start_mode{name="remoteregistry",start_mode="system"} 0
+windows_service_start_mode{name="retaildemo",start_mode="auto"} 0
+windows_service_start_mode{name="retaildemo",start_mode="boot"} 0
+windows_service_start_mode{name="retaildemo",start_mode="disabled"} 0
+windows_service_start_mode{name="retaildemo",start_mode="manual"} 1
+windows_service_start_mode{name="retaildemo",start_mode="system"} 0
 windows_service_start_mode{name="rmsvc",start_mode="auto"} 0
 windows_service_start_mode{name="rmsvc",start_mode="boot"} 0
 windows_service_start_mode{name="rmsvc",start_mode="disabled"} 0
@@ -837,16 +1091,6 @@ windows_service_start_mode{name="rpcss",start_mode="boot"} 0
 windows_service_start_mode{name="rpcss",start_mode="disabled"} 0
 windows_service_start_mode{name="rpcss",start_mode="manual"} 0
 windows_service_start_mode{name="rpcss",start_mode="system"} 0
-windows_service_start_mode{name="rsopprov",start_mode="auto"} 0
-windows_service_start_mode{name="rsopprov",start_mode="boot"} 0
-windows_service_start_mode{name="rsopprov",start_mode="disabled"} 0
-windows_service_start_mode{name="rsopprov",start_mode="manual"} 1
-windows_service_start_mode{name="rsopprov",start_mode="system"} 0
-windows_service_start_mode{name="sacsvr",start_mode="auto"} 0
-windows_service_start_mode{name="sacsvr",start_mode="boot"} 0
-windows_service_start_mode{name="sacsvr",start_mode="disabled"} 0
-windows_service_start_mode{name="sacsvr",start_mode="manual"} 1
-windows_service_start_mode{name="sacsvr",start_mode="system"} 0
 windows_service_start_mode{name="samss",start_mode="auto"} 1
 windows_service_start_mode{name="samss",start_mode="boot"} 0
 windows_service_start_mode{name="samss",start_mode="disabled"} 0
@@ -854,8 +1098,8 @@ windows_service_start_mode{name="samss",start_mode="manual"} 0
 windows_service_start_mode{name="samss",start_mode="system"} 0
 windows_service_start_mode{name="scardsvr",start_mode="auto"} 0
 windows_service_start_mode{name="scardsvr",start_mode="boot"} 0
-windows_service_start_mode{name="scardsvr",start_mode="disabled"} 1
-windows_service_start_mode{name="scardsvr",start_mode="manual"} 0
+windows_service_start_mode{name="scardsvr",start_mode="disabled"} 0
+windows_service_start_mode{name="scardsvr",start_mode="manual"} 1
 windows_service_start_mode{name="scardsvr",start_mode="system"} 0
 windows_service_start_mode{name="scdeviceenum",start_mode="auto"} 0
 windows_service_start_mode{name="scdeviceenum",start_mode="boot"} 0
@@ -872,16 +1116,36 @@ windows_service_start_mode{name="scpolicysvc",start_mode="boot"} 0
 windows_service_start_mode{name="scpolicysvc",start_mode="disabled"} 0
 windows_service_start_mode{name="scpolicysvc",start_mode="manual"} 1
 windows_service_start_mode{name="scpolicysvc",start_mode="system"} 0
+windows_service_start_mode{name="sdrsvc",start_mode="auto"} 0
+windows_service_start_mode{name="sdrsvc",start_mode="boot"} 0
+windows_service_start_mode{name="sdrsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="sdrsvc",start_mode="manual"} 1
+windows_service_start_mode{name="sdrsvc",start_mode="system"} 0
 windows_service_start_mode{name="seclogon",start_mode="auto"} 0
 windows_service_start_mode{name="seclogon",start_mode="boot"} 0
 windows_service_start_mode{name="seclogon",start_mode="disabled"} 0
 windows_service_start_mode{name="seclogon",start_mode="manual"} 1
 windows_service_start_mode{name="seclogon",start_mode="system"} 0
+windows_service_start_mode{name="securityhealthservice",start_mode="auto"} 0
+windows_service_start_mode{name="securityhealthservice",start_mode="boot"} 0
+windows_service_start_mode{name="securityhealthservice",start_mode="disabled"} 0
+windows_service_start_mode{name="securityhealthservice",start_mode="manual"} 1
+windows_service_start_mode{name="securityhealthservice",start_mode="system"} 0
+windows_service_start_mode{name="semgrsvc",start_mode="auto"} 0
+windows_service_start_mode{name="semgrsvc",start_mode="boot"} 0
+windows_service_start_mode{name="semgrsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="semgrsvc",start_mode="manual"} 1
+windows_service_start_mode{name="semgrsvc",start_mode="system"} 0
 windows_service_start_mode{name="sens",start_mode="auto"} 1
 windows_service_start_mode{name="sens",start_mode="boot"} 0
 windows_service_start_mode{name="sens",start_mode="disabled"} 0
 windows_service_start_mode{name="sens",start_mode="manual"} 0
 windows_service_start_mode{name="sens",start_mode="system"} 0
+windows_service_start_mode{name="sense",start_mode="auto"} 0
+windows_service_start_mode{name="sense",start_mode="boot"} 0
+windows_service_start_mode{name="sense",start_mode="disabled"} 0
+windows_service_start_mode{name="sense",start_mode="manual"} 1
+windows_service_start_mode{name="sense",start_mode="system"} 0
 windows_service_start_mode{name="sensordataservice",start_mode="auto"} 0
 windows_service_start_mode{name="sensordataservice",start_mode="boot"} 0
 windows_service_start_mode{name="sensordataservice",start_mode="disabled"} 0
@@ -902,26 +1166,51 @@ windows_service_start_mode{name="sessionenv",start_mode="boot"} 0
 windows_service_start_mode{name="sessionenv",start_mode="disabled"} 0
 windows_service_start_mode{name="sessionenv",start_mode="manual"} 1
 windows_service_start_mode{name="sessionenv",start_mode="system"} 0
+windows_service_start_mode{name="sgrmbroker",start_mode="auto"} 1
+windows_service_start_mode{name="sgrmbroker",start_mode="boot"} 0
+windows_service_start_mode{name="sgrmbroker",start_mode="disabled"} 0
+windows_service_start_mode{name="sgrmbroker",start_mode="manual"} 0
+windows_service_start_mode{name="sgrmbroker",start_mode="system"} 0
 windows_service_start_mode{name="sharedaccess",start_mode="auto"} 0
 windows_service_start_mode{name="sharedaccess",start_mode="boot"} 0
 windows_service_start_mode{name="sharedaccess",start_mode="disabled"} 0
 windows_service_start_mode{name="sharedaccess",start_mode="manual"} 1
 windows_service_start_mode{name="sharedaccess",start_mode="system"} 0
+windows_service_start_mode{name="sharedrealitysvc",start_mode="auto"} 0
+windows_service_start_mode{name="sharedrealitysvc",start_mode="boot"} 0
+windows_service_start_mode{name="sharedrealitysvc",start_mode="disabled"} 0
+windows_service_start_mode{name="sharedrealitysvc",start_mode="manual"} 1
+windows_service_start_mode{name="sharedrealitysvc",start_mode="system"} 0
 windows_service_start_mode{name="shellhwdetection",start_mode="auto"} 1
 windows_service_start_mode{name="shellhwdetection",start_mode="boot"} 0
 windows_service_start_mode{name="shellhwdetection",start_mode="disabled"} 0
 windows_service_start_mode{name="shellhwdetection",start_mode="manual"} 0
 windows_service_start_mode{name="shellhwdetection",start_mode="system"} 0
+windows_service_start_mode{name="shpamsvc",start_mode="auto"} 0
+windows_service_start_mode{name="shpamsvc",start_mode="boot"} 0
+windows_service_start_mode{name="shpamsvc",start_mode="disabled"} 1
+windows_service_start_mode{name="shpamsvc",start_mode="manual"} 0
+windows_service_start_mode{name="shpamsvc",start_mode="system"} 0
 windows_service_start_mode{name="smphost",start_mode="auto"} 0
 windows_service_start_mode{name="smphost",start_mode="boot"} 0
 windows_service_start_mode{name="smphost",start_mode="disabled"} 0
 windows_service_start_mode{name="smphost",start_mode="manual"} 1
 windows_service_start_mode{name="smphost",start_mode="system"} 0
+windows_service_start_mode{name="smsrouter",start_mode="auto"} 0
+windows_service_start_mode{name="smsrouter",start_mode="boot"} 0
+windows_service_start_mode{name="smsrouter",start_mode="disabled"} 0
+windows_service_start_mode{name="smsrouter",start_mode="manual"} 1
+windows_service_start_mode{name="smsrouter",start_mode="system"} 0
 windows_service_start_mode{name="snmptrap",start_mode="auto"} 0
 windows_service_start_mode{name="snmptrap",start_mode="boot"} 0
 windows_service_start_mode{name="snmptrap",start_mode="disabled"} 0
 windows_service_start_mode{name="snmptrap",start_mode="manual"} 1
 windows_service_start_mode{name="snmptrap",start_mode="system"} 0
+windows_service_start_mode{name="spectrum",start_mode="auto"} 0
+windows_service_start_mode{name="spectrum",start_mode="boot"} 0
+windows_service_start_mode{name="spectrum",start_mode="disabled"} 0
+windows_service_start_mode{name="spectrum",start_mode="manual"} 1
+windows_service_start_mode{name="spectrum",start_mode="system"} 0
 windows_service_start_mode{name="spooler",start_mode="auto"} 1
 windows_service_start_mode{name="spooler",start_mode="boot"} 0
 windows_service_start_mode{name="spooler",start_mode="disabled"} 0
@@ -937,6 +1226,11 @@ windows_service_start_mode{name="ssdpsrv",start_mode="boot"} 0
 windows_service_start_mode{name="ssdpsrv",start_mode="disabled"} 0
 windows_service_start_mode{name="ssdpsrv",start_mode="manual"} 1
 windows_service_start_mode{name="ssdpsrv",start_mode="system"} 0
+windows_service_start_mode{name="ssh-agent",start_mode="auto"} 0
+windows_service_start_mode{name="ssh-agent",start_mode="boot"} 0
+windows_service_start_mode{name="ssh-agent",start_mode="disabled"} 1
+windows_service_start_mode{name="ssh-agent",start_mode="manual"} 0
+windows_service_start_mode{name="ssh-agent",start_mode="system"} 0
 windows_service_start_mode{name="sstpsvc",start_mode="auto"} 0
 windows_service_start_mode{name="sstpsvc",start_mode="boot"} 0
 windows_service_start_mode{name="sstpsvc",start_mode="disabled"} 0
@@ -967,10 +1261,10 @@ windows_service_start_mode{name="swprv",start_mode="boot"} 0
 windows_service_start_mode{name="swprv",start_mode="disabled"} 0
 windows_service_start_mode{name="swprv",start_mode="manual"} 1
 windows_service_start_mode{name="swprv",start_mode="system"} 0
-windows_service_start_mode{name="sysmain",start_mode="auto"} 0
+windows_service_start_mode{name="sysmain",start_mode="auto"} 1
 windows_service_start_mode{name="sysmain",start_mode="boot"} 0
 windows_service_start_mode{name="sysmain",start_mode="disabled"} 0
-windows_service_start_mode{name="sysmain",start_mode="manual"} 1
+windows_service_start_mode{name="sysmain",start_mode="manual"} 0
 windows_service_start_mode{name="sysmain",start_mode="system"} 0
 windows_service_start_mode{name="systemeventsbroker",start_mode="auto"} 1
 windows_service_start_mode{name="systemeventsbroker",start_mode="boot"} 0
@@ -987,6 +1281,11 @@ windows_service_start_mode{name="tapisrv",start_mode="boot"} 0
 windows_service_start_mode{name="tapisrv",start_mode="disabled"} 0
 windows_service_start_mode{name="tapisrv",start_mode="manual"} 1
 windows_service_start_mode{name="tapisrv",start_mode="system"} 0
+windows_service_start_mode{name="te.service",start_mode="auto"} 0
+windows_service_start_mode{name="te.service",start_mode="boot"} 0
+windows_service_start_mode{name="te.service",start_mode="disabled"} 0
+windows_service_start_mode{name="te.service",start_mode="manual"} 1
+windows_service_start_mode{name="te.service",start_mode="system"} 0
 windows_service_start_mode{name="termservice",start_mode="auto"} 0
 windows_service_start_mode{name="termservice",start_mode="boot"} 0
 windows_service_start_mode{name="termservice",start_mode="disabled"} 0
@@ -1002,21 +1301,26 @@ windows_service_start_mode{name="tieringengineservice",start_mode="boot"} 0
 windows_service_start_mode{name="tieringengineservice",start_mode="disabled"} 0
 windows_service_start_mode{name="tieringengineservice",start_mode="manual"} 1
 windows_service_start_mode{name="tieringengineservice",start_mode="system"} 0
-windows_service_start_mode{name="tiledatamodelsvc",start_mode="auto"} 1
-windows_service_start_mode{name="tiledatamodelsvc",start_mode="boot"} 0
-windows_service_start_mode{name="tiledatamodelsvc",start_mode="disabled"} 0
-windows_service_start_mode{name="tiledatamodelsvc",start_mode="manual"} 0
-windows_service_start_mode{name="tiledatamodelsvc",start_mode="system"} 0
 windows_service_start_mode{name="timebrokersvc",start_mode="auto"} 0
 windows_service_start_mode{name="timebrokersvc",start_mode="boot"} 0
 windows_service_start_mode{name="timebrokersvc",start_mode="disabled"} 0
 windows_service_start_mode{name="timebrokersvc",start_mode="manual"} 1
 windows_service_start_mode{name="timebrokersvc",start_mode="system"} 0
+windows_service_start_mode{name="tokenbroker",start_mode="auto"} 0
+windows_service_start_mode{name="tokenbroker",start_mode="boot"} 0
+windows_service_start_mode{name="tokenbroker",start_mode="disabled"} 0
+windows_service_start_mode{name="tokenbroker",start_mode="manual"} 1
+windows_service_start_mode{name="tokenbroker",start_mode="system"} 0
 windows_service_start_mode{name="trkwks",start_mode="auto"} 1
 windows_service_start_mode{name="trkwks",start_mode="boot"} 0
 windows_service_start_mode{name="trkwks",start_mode="disabled"} 0
 windows_service_start_mode{name="trkwks",start_mode="manual"} 0
 windows_service_start_mode{name="trkwks",start_mode="system"} 0
+windows_service_start_mode{name="troubleshootingsvc",start_mode="auto"} 0
+windows_service_start_mode{name="troubleshootingsvc",start_mode="boot"} 0
+windows_service_start_mode{name="troubleshootingsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="troubleshootingsvc",start_mode="manual"} 1
+windows_service_start_mode{name="troubleshootingsvc",start_mode="system"} 0
 windows_service_start_mode{name="trustedinstaller",start_mode="auto"} 0
 windows_service_start_mode{name="trustedinstaller",start_mode="boot"} 0
 windows_service_start_mode{name="trustedinstaller",start_mode="disabled"} 0
@@ -1027,51 +1331,46 @@ windows_service_start_mode{name="tzautoupdate",start_mode="boot"} 0
 windows_service_start_mode{name="tzautoupdate",start_mode="disabled"} 1
 windows_service_start_mode{name="tzautoupdate",start_mode="manual"} 0
 windows_service_start_mode{name="tzautoupdate",start_mode="system"} 0
-windows_service_start_mode{name="ualsvc",start_mode="auto"} 1
-windows_service_start_mode{name="ualsvc",start_mode="boot"} 0
-windows_service_start_mode{name="ualsvc",start_mode="disabled"} 0
-windows_service_start_mode{name="ualsvc",start_mode="manual"} 0
-windows_service_start_mode{name="ualsvc",start_mode="system"} 0
 windows_service_start_mode{name="uevagentservice",start_mode="auto"} 0
 windows_service_start_mode{name="uevagentservice",start_mode="boot"} 0
 windows_service_start_mode{name="uevagentservice",start_mode="disabled"} 1
 windows_service_start_mode{name="uevagentservice",start_mode="manual"} 0
 windows_service_start_mode{name="uevagentservice",start_mode="system"} 0
-windows_service_start_mode{name="ui0detect",start_mode="auto"} 0
-windows_service_start_mode{name="ui0detect",start_mode="boot"} 0
-windows_service_start_mode{name="ui0detect",start_mode="disabled"} 0
-windows_service_start_mode{name="ui0detect",start_mode="manual"} 1
-windows_service_start_mode{name="ui0detect",start_mode="system"} 0
 windows_service_start_mode{name="umrdpservice",start_mode="auto"} 0
 windows_service_start_mode{name="umrdpservice",start_mode="boot"} 0
 windows_service_start_mode{name="umrdpservice",start_mode="disabled"} 0
 windows_service_start_mode{name="umrdpservice",start_mode="manual"} 1
 windows_service_start_mode{name="umrdpservice",start_mode="system"} 0
-windows_service_start_mode{name="unistoresvc_225e3",start_mode="auto"} 0
-windows_service_start_mode{name="unistoresvc_225e3",start_mode="boot"} 0
-windows_service_start_mode{name="unistoresvc_225e3",start_mode="disabled"} 0
-windows_service_start_mode{name="unistoresvc_225e3",start_mode="manual"} 1
-windows_service_start_mode{name="unistoresvc_225e3",start_mode="system"} 0
+windows_service_start_mode{name="unistoresvc_390e7",start_mode="auto"} 0
+windows_service_start_mode{name="unistoresvc_390e7",start_mode="boot"} 0
+windows_service_start_mode{name="unistoresvc_390e7",start_mode="disabled"} 0
+windows_service_start_mode{name="unistoresvc_390e7",start_mode="manual"} 1
+windows_service_start_mode{name="unistoresvc_390e7",start_mode="system"} 0
 windows_service_start_mode{name="upnphost",start_mode="auto"} 0
 windows_service_start_mode{name="upnphost",start_mode="boot"} 0
 windows_service_start_mode{name="upnphost",start_mode="disabled"} 0
 windows_service_start_mode{name="upnphost",start_mode="manual"} 1
 windows_service_start_mode{name="upnphost",start_mode="system"} 0
-windows_service_start_mode{name="userdatasvc_225e3",start_mode="auto"} 0
-windows_service_start_mode{name="userdatasvc_225e3",start_mode="boot"} 0
-windows_service_start_mode{name="userdatasvc_225e3",start_mode="disabled"} 0
-windows_service_start_mode{name="userdatasvc_225e3",start_mode="manual"} 1
-windows_service_start_mode{name="userdatasvc_225e3",start_mode="system"} 0
+windows_service_start_mode{name="userdatasvc_390e7",start_mode="auto"} 0
+windows_service_start_mode{name="userdatasvc_390e7",start_mode="boot"} 0
+windows_service_start_mode{name="userdatasvc_390e7",start_mode="disabled"} 0
+windows_service_start_mode{name="userdatasvc_390e7",start_mode="manual"} 1
+windows_service_start_mode{name="userdatasvc_390e7",start_mode="system"} 0
 windows_service_start_mode{name="usermanager",start_mode="auto"} 1
 windows_service_start_mode{name="usermanager",start_mode="boot"} 0
 windows_service_start_mode{name="usermanager",start_mode="disabled"} 0
 windows_service_start_mode{name="usermanager",start_mode="manual"} 0
 windows_service_start_mode{name="usermanager",start_mode="system"} 0
-windows_service_start_mode{name="usosvc",start_mode="auto"} 0
+windows_service_start_mode{name="usosvc",start_mode="auto"} 1
 windows_service_start_mode{name="usosvc",start_mode="boot"} 0
 windows_service_start_mode{name="usosvc",start_mode="disabled"} 0
-windows_service_start_mode{name="usosvc",start_mode="manual"} 1
+windows_service_start_mode{name="usosvc",start_mode="manual"} 0
 windows_service_start_mode{name="usosvc",start_mode="system"} 0
+windows_service_start_mode{name="vacsvc",start_mode="auto"} 0
+windows_service_start_mode{name="vacsvc",start_mode="boot"} 0
+windows_service_start_mode{name="vacsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="vacsvc",start_mode="manual"} 1
+windows_service_start_mode{name="vacsvc",start_mode="system"} 0
 windows_service_start_mode{name="vaultsvc",start_mode="auto"} 0
 windows_service_start_mode{name="vaultsvc",start_mode="boot"} 0
 windows_service_start_mode{name="vaultsvc",start_mode="disabled"} 0
@@ -1132,31 +1431,31 @@ windows_service_start_mode{name="vss",start_mode="boot"} 0
 windows_service_start_mode{name="vss",start_mode="disabled"} 0
 windows_service_start_mode{name="vss",start_mode="manual"} 1
 windows_service_start_mode{name="vss",start_mode="system"} 0
-windows_service_start_mode{name="w32time",start_mode="auto"} 1
+windows_service_start_mode{name="w32time",start_mode="auto"} 0
 windows_service_start_mode{name="w32time",start_mode="boot"} 0
 windows_service_start_mode{name="w32time",start_mode="disabled"} 0
-windows_service_start_mode{name="w32time",start_mode="manual"} 0
+windows_service_start_mode{name="w32time",start_mode="manual"} 1
 windows_service_start_mode{name="w32time",start_mode="system"} 0
-windows_service_start_mode{name="w3logsvc",start_mode="auto"} 0
-windows_service_start_mode{name="w3logsvc",start_mode="boot"} 0
-windows_service_start_mode{name="w3logsvc",start_mode="disabled"} 0
-windows_service_start_mode{name="w3logsvc",start_mode="manual"} 1
-windows_service_start_mode{name="w3logsvc",start_mode="system"} 0
-windows_service_start_mode{name="w3svc",start_mode="auto"} 1
-windows_service_start_mode{name="w3svc",start_mode="boot"} 0
-windows_service_start_mode{name="w3svc",start_mode="disabled"} 0
-windows_service_start_mode{name="w3svc",start_mode="manual"} 0
-windows_service_start_mode{name="w3svc",start_mode="system"} 0
+windows_service_start_mode{name="waasmedicsvc",start_mode="auto"} 0
+windows_service_start_mode{name="waasmedicsvc",start_mode="boot"} 0
+windows_service_start_mode{name="waasmedicsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="waasmedicsvc",start_mode="manual"} 1
+windows_service_start_mode{name="waasmedicsvc",start_mode="system"} 0
 windows_service_start_mode{name="walletservice",start_mode="auto"} 0
 windows_service_start_mode{name="walletservice",start_mode="boot"} 0
 windows_service_start_mode{name="walletservice",start_mode="disabled"} 0
 windows_service_start_mode{name="walletservice",start_mode="manual"} 1
 windows_service_start_mode{name="walletservice",start_mode="system"} 0
-windows_service_start_mode{name="was",start_mode="auto"} 0
-windows_service_start_mode{name="was",start_mode="boot"} 0
-windows_service_start_mode{name="was",start_mode="disabled"} 0
-windows_service_start_mode{name="was",start_mode="manual"} 1
-windows_service_start_mode{name="was",start_mode="system"} 0
+windows_service_start_mode{name="warpjitsvc",start_mode="auto"} 0
+windows_service_start_mode{name="warpjitsvc",start_mode="boot"} 0
+windows_service_start_mode{name="warpjitsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="warpjitsvc",start_mode="manual"} 1
+windows_service_start_mode{name="warpjitsvc",start_mode="system"} 0
+windows_service_start_mode{name="wbengine",start_mode="auto"} 0
+windows_service_start_mode{name="wbengine",start_mode="boot"} 0
+windows_service_start_mode{name="wbengine",start_mode="disabled"} 0
+windows_service_start_mode{name="wbengine",start_mode="manual"} 1
+windows_service_start_mode{name="wbengine",start_mode="system"} 0
 windows_service_start_mode{name="wbiosrvc",start_mode="auto"} 0
 windows_service_start_mode{name="wbiosrvc",start_mode="boot"} 0
 windows_service_start_mode{name="wbiosrvc",start_mode="disabled"} 0
@@ -1167,6 +1466,11 @@ windows_service_start_mode{name="wcmsvc",start_mode="boot"} 0
 windows_service_start_mode{name="wcmsvc",start_mode="disabled"} 0
 windows_service_start_mode{name="wcmsvc",start_mode="manual"} 0
 windows_service_start_mode{name="wcmsvc",start_mode="system"} 0
+windows_service_start_mode{name="wcncsvc",start_mode="auto"} 0
+windows_service_start_mode{name="wcncsvc",start_mode="boot"} 0
+windows_service_start_mode{name="wcncsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="wcncsvc",start_mode="manual"} 1
+windows_service_start_mode{name="wcncsvc",start_mode="system"} 0
 windows_service_start_mode{name="wdiservicehost",start_mode="auto"} 0
 windows_service_start_mode{name="wdiservicehost",start_mode="boot"} 0
 windows_service_start_mode{name="wdiservicehost",start_mode="disabled"} 0
@@ -1182,6 +1486,11 @@ windows_service_start_mode{name="wdnissvc",start_mode="boot"} 0
 windows_service_start_mode{name="wdnissvc",start_mode="disabled"} 0
 windows_service_start_mode{name="wdnissvc",start_mode="manual"} 1
 windows_service_start_mode{name="wdnissvc",start_mode="system"} 0
+windows_service_start_mode{name="webclient",start_mode="auto"} 0
+windows_service_start_mode{name="webclient",start_mode="boot"} 0
+windows_service_start_mode{name="webclient",start_mode="disabled"} 0
+windows_service_start_mode{name="webclient",start_mode="manual"} 1
+windows_service_start_mode{name="webclient",start_mode="system"} 0
 windows_service_start_mode{name="wecsvc",start_mode="auto"} 0
 windows_service_start_mode{name="wecsvc",start_mode="boot"} 0
 windows_service_start_mode{name="wecsvc",start_mode="disabled"} 0
@@ -1202,6 +1511,11 @@ windows_service_start_mode{name="wersvc",start_mode="boot"} 0
 windows_service_start_mode{name="wersvc",start_mode="disabled"} 0
 windows_service_start_mode{name="wersvc",start_mode="manual"} 1
 windows_service_start_mode{name="wersvc",start_mode="system"} 0
+windows_service_start_mode{name="wfdsconmgrsvc",start_mode="auto"} 0
+windows_service_start_mode{name="wfdsconmgrsvc",start_mode="boot"} 0
+windows_service_start_mode{name="wfdsconmgrsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="wfdsconmgrsvc",start_mode="manual"} 1
+windows_service_start_mode{name="wfdsconmgrsvc",start_mode="system"} 0
 windows_service_start_mode{name="wiarpc",start_mode="auto"} 0
 windows_service_start_mode{name="wiarpc",start_mode="boot"} 0
 windows_service_start_mode{name="wiarpc",start_mode="disabled"} 0
@@ -1222,16 +1536,21 @@ windows_service_start_mode{name="winmgmt",start_mode="boot"} 0
 windows_service_start_mode{name="winmgmt",start_mode="disabled"} 0
 windows_service_start_mode{name="winmgmt",start_mode="manual"} 0
 windows_service_start_mode{name="winmgmt",start_mode="system"} 0
-windows_service_start_mode{name="winrm",start_mode="auto"} 1
+windows_service_start_mode{name="winrm",start_mode="auto"} 0
 windows_service_start_mode{name="winrm",start_mode="boot"} 0
 windows_service_start_mode{name="winrm",start_mode="disabled"} 0
-windows_service_start_mode{name="winrm",start_mode="manual"} 0
+windows_service_start_mode{name="winrm",start_mode="manual"} 1
 windows_service_start_mode{name="winrm",start_mode="system"} 0
 windows_service_start_mode{name="wisvc",start_mode="auto"} 0
 windows_service_start_mode{name="wisvc",start_mode="boot"} 0
 windows_service_start_mode{name="wisvc",start_mode="disabled"} 0
 windows_service_start_mode{name="wisvc",start_mode="manual"} 1
 windows_service_start_mode{name="wisvc",start_mode="system"} 0
+windows_service_start_mode{name="wlansvc",start_mode="auto"} 0
+windows_service_start_mode{name="wlansvc",start_mode="boot"} 0
+windows_service_start_mode{name="wlansvc",start_mode="disabled"} 0
+windows_service_start_mode{name="wlansvc",start_mode="manual"} 1
+windows_service_start_mode{name="wlansvc",start_mode="system"} 0
 windows_service_start_mode{name="wlidsvc",start_mode="auto"} 0
 windows_service_start_mode{name="wlidsvc",start_mode="boot"} 0
 windows_service_start_mode{name="wlidsvc",start_mode="disabled"} 0
@@ -1242,16 +1561,36 @@ windows_service_start_mode{name="wlms",start_mode="boot"} 0
 windows_service_start_mode{name="wlms",start_mode="disabled"} 0
 windows_service_start_mode{name="wlms",start_mode="manual"} 0
 windows_service_start_mode{name="wlms",start_mode="system"} 0
-windows_service_start_mode{name="windows_exporter",start_mode="auto"} 1
-windows_service_start_mode{name="windows_exporter",start_mode="boot"} 0
-windows_service_start_mode{name="windows_exporter",start_mode="disabled"} 0
-windows_service_start_mode{name="windows_exporter",start_mode="manual"} 0
-windows_service_start_mode{name="windows_exporter",start_mode="system"} 0
+windows_service_start_mode{name="wlpasvc",start_mode="auto"} 0
+windows_service_start_mode{name="wlpasvc",start_mode="boot"} 0
+windows_service_start_mode{name="wlpasvc",start_mode="disabled"} 0
+windows_service_start_mode{name="wlpasvc",start_mode="manual"} 1
+windows_service_start_mode{name="wlpasvc",start_mode="system"} 0
+windows_service_start_mode{name="wmansvc",start_mode="auto"} 0
+windows_service_start_mode{name="wmansvc",start_mode="boot"} 0
+windows_service_start_mode{name="wmansvc",start_mode="disabled"} 0
+windows_service_start_mode{name="wmansvc",start_mode="manual"} 1
+windows_service_start_mode{name="wmansvc",start_mode="system"} 0
 windows_service_start_mode{name="wmiapsrv",start_mode="auto"} 0
 windows_service_start_mode{name="wmiapsrv",start_mode="boot"} 0
 windows_service_start_mode{name="wmiapsrv",start_mode="disabled"} 0
 windows_service_start_mode{name="wmiapsrv",start_mode="manual"} 1
 windows_service_start_mode{name="wmiapsrv",start_mode="system"} 0
+windows_service_start_mode{name="wmpnetworksvc",start_mode="auto"} 0
+windows_service_start_mode{name="wmpnetworksvc",start_mode="boot"} 0
+windows_service_start_mode{name="wmpnetworksvc",start_mode="disabled"} 0
+windows_service_start_mode{name="wmpnetworksvc",start_mode="manual"} 1
+windows_service_start_mode{name="wmpnetworksvc",start_mode="system"} 0
+windows_service_start_mode{name="workfolderssvc",start_mode="auto"} 0
+windows_service_start_mode{name="workfolderssvc",start_mode="boot"} 0
+windows_service_start_mode{name="workfolderssvc",start_mode="disabled"} 0
+windows_service_start_mode{name="workfolderssvc",start_mode="manual"} 1
+windows_service_start_mode{name="workfolderssvc",start_mode="system"} 0
+windows_service_start_mode{name="wpcmonsvc",start_mode="auto"} 0
+windows_service_start_mode{name="wpcmonsvc",start_mode="boot"} 0
+windows_service_start_mode{name="wpcmonsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="wpcmonsvc",start_mode="manual"} 1
+windows_service_start_mode{name="wpcmonsvc",start_mode="system"} 0
 windows_service_start_mode{name="wpdbusenum",start_mode="auto"} 0
 windows_service_start_mode{name="wpdbusenum",start_mode="boot"} 0
 windows_service_start_mode{name="wpdbusenum",start_mode="disabled"} 0
@@ -1262,14 +1601,19 @@ windows_service_start_mode{name="wpnservice",start_mode="boot"} 0
 windows_service_start_mode{name="wpnservice",start_mode="disabled"} 0
 windows_service_start_mode{name="wpnservice",start_mode="manual"} 0
 windows_service_start_mode{name="wpnservice",start_mode="system"} 0
-windows_service_start_mode{name="wpnuserservice_225e3",start_mode="auto"} 0
-windows_service_start_mode{name="wpnuserservice_225e3",start_mode="boot"} 0
-windows_service_start_mode{name="wpnuserservice_225e3",start_mode="disabled"} 0
-windows_service_start_mode{name="wpnuserservice_225e3",start_mode="manual"} 1
-windows_service_start_mode{name="wpnuserservice_225e3",start_mode="system"} 0
-windows_service_start_mode{name="wsearch",start_mode="auto"} 0
+windows_service_start_mode{name="wpnuserservice_390e7",start_mode="auto"} 1
+windows_service_start_mode{name="wpnuserservice_390e7",start_mode="boot"} 0
+windows_service_start_mode{name="wpnuserservice_390e7",start_mode="disabled"} 0
+windows_service_start_mode{name="wpnuserservice_390e7",start_mode="manual"} 0
+windows_service_start_mode{name="wpnuserservice_390e7",start_mode="system"} 0
+windows_service_start_mode{name="wscsvc",start_mode="auto"} 1
+windows_service_start_mode{name="wscsvc",start_mode="boot"} 0
+windows_service_start_mode{name="wscsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="wscsvc",start_mode="manual"} 0
+windows_service_start_mode{name="wscsvc",start_mode="system"} 0
+windows_service_start_mode{name="wsearch",start_mode="auto"} 1
 windows_service_start_mode{name="wsearch",start_mode="boot"} 0
-windows_service_start_mode{name="wsearch",start_mode="disabled"} 1
+windows_service_start_mode{name="wsearch",start_mode="disabled"} 0
 windows_service_start_mode{name="wsearch",start_mode="manual"} 0
 windows_service_start_mode{name="wsearch",start_mode="system"} 0
 windows_service_start_mode{name="wuauserv",start_mode="auto"} 0
@@ -1277,11 +1621,11 @@ windows_service_start_mode{name="wuauserv",start_mode="boot"} 0
 windows_service_start_mode{name="wuauserv",start_mode="disabled"} 0
 windows_service_start_mode{name="wuauserv",start_mode="manual"} 1
 windows_service_start_mode{name="wuauserv",start_mode="system"} 0
-windows_service_start_mode{name="wudfsvc",start_mode="auto"} 0
-windows_service_start_mode{name="wudfsvc",start_mode="boot"} 0
-windows_service_start_mode{name="wudfsvc",start_mode="disabled"} 0
-windows_service_start_mode{name="wudfsvc",start_mode="manual"} 1
-windows_service_start_mode{name="wudfsvc",start_mode="system"} 0
+windows_service_start_mode{name="wwansvc",start_mode="auto"} 0
+windows_service_start_mode{name="wwansvc",start_mode="boot"} 0
+windows_service_start_mode{name="wwansvc",start_mode="disabled"} 0
+windows_service_start_mode{name="wwansvc",start_mode="manual"} 1
+windows_service_start_mode{name="wwansvc",start_mode="system"} 0
 windows_service_start_mode{name="xblauthmanager",start_mode="auto"} 0
 windows_service_start_mode{name="xblauthmanager",start_mode="boot"} 0
 windows_service_start_mode{name="xblauthmanager",start_mode="disabled"} 0
@@ -1292,8 +1636,26 @@ windows_service_start_mode{name="xblgamesave",start_mode="boot"} 0
 windows_service_start_mode{name="xblgamesave",start_mode="disabled"} 0
 windows_service_start_mode{name="xblgamesave",start_mode="manual"} 1
 windows_service_start_mode{name="xblgamesave",start_mode="system"} 0
+windows_service_start_mode{name="xboxgipsvc",start_mode="auto"} 0
+windows_service_start_mode{name="xboxgipsvc",start_mode="boot"} 0
+windows_service_start_mode{name="xboxgipsvc",start_mode="disabled"} 0
+windows_service_start_mode{name="xboxgipsvc",start_mode="manual"} 1
+windows_service_start_mode{name="xboxgipsvc",start_mode="system"} 0
+windows_service_start_mode{name="xboxnetapisvc",start_mode="auto"} 0
+windows_service_start_mode{name="xboxnetapisvc",start_mode="boot"} 0
+windows_service_start_mode{name="xboxnetapisvc",start_mode="disabled"} 0
+windows_service_start_mode{name="xboxnetapisvc",start_mode="manual"} 1
+windows_service_start_mode{name="xboxnetapisvc",start_mode="system"} 0
 # HELP windows_service_state The state of the service (State)
 # TYPE windows_service_state gauge
+windows_service_state{name="aarsvc_390e7",state="continue pending"} 0
+windows_service_state{name="aarsvc_390e7",state="pause pending"} 0
+windows_service_state{name="aarsvc_390e7",state="paused"} 0
+windows_service_state{name="aarsvc_390e7",state="running"} 0
+windows_service_state{name="aarsvc_390e7",state="start pending"} 0
+windows_service_state{name="aarsvc_390e7",state="stop pending"} 0
+windows_service_state{name="aarsvc_390e7",state="stopped"} 1
+windows_service_state{name="aarsvc_390e7",state="unknown"} 0
 windows_service_state{name="ajrouter",state="continue pending"} 0
 windows_service_state{name="ajrouter",state="pause pending"} 0
 windows_service_state{name="ajrouter",state="paused"} 0
@@ -1310,14 +1672,6 @@ windows_service_state{name="alg",state="start pending"} 0
 windows_service_state{name="alg",state="stop pending"} 0
 windows_service_state{name="alg",state="stopped"} 1
 windows_service_state{name="alg",state="unknown"} 0
-windows_service_state{name="apphostsvc",state="continue pending"} 0
-windows_service_state{name="apphostsvc",state="pause pending"} 0
-windows_service_state{name="apphostsvc",state="paused"} 0
-windows_service_state{name="apphostsvc",state="running"} 1
-windows_service_state{name="apphostsvc",state="start pending"} 0
-windows_service_state{name="apphostsvc",state="stop pending"} 0
-windows_service_state{name="apphostsvc",state="stopped"} 0
-windows_service_state{name="apphostsvc",state="unknown"} 0
 windows_service_state{name="appidsvc",state="continue pending"} 0
 windows_service_state{name="appidsvc",state="pause pending"} 0
 windows_service_state{name="appidsvc",state="paused"} 0
@@ -1329,18 +1683,18 @@ windows_service_state{name="appidsvc",state="unknown"} 0
 windows_service_state{name="appinfo",state="continue pending"} 0
 windows_service_state{name="appinfo",state="pause pending"} 0
 windows_service_state{name="appinfo",state="paused"} 0
-windows_service_state{name="appinfo",state="running"} 0
+windows_service_state{name="appinfo",state="running"} 1
 windows_service_state{name="appinfo",state="start pending"} 0
 windows_service_state{name="appinfo",state="stop pending"} 0
-windows_service_state{name="appinfo",state="stopped"} 1
+windows_service_state{name="appinfo",state="stopped"} 0
 windows_service_state{name="appinfo",state="unknown"} 0
 windows_service_state{name="appmgmt",state="continue pending"} 0
 windows_service_state{name="appmgmt",state="pause pending"} 0
 windows_service_state{name="appmgmt",state="paused"} 0
-windows_service_state{name="appmgmt",state="running"} 1
+windows_service_state{name="appmgmt",state="running"} 0
 windows_service_state{name="appmgmt",state="start pending"} 0
 windows_service_state{name="appmgmt",state="stop pending"} 0
-windows_service_state{name="appmgmt",state="stopped"} 0
+windows_service_state{name="appmgmt",state="stopped"} 1
 windows_service_state{name="appmgmt",state="unknown"} 0
 windows_service_state{name="appreadiness",state="continue pending"} 0
 windows_service_state{name="appreadiness",state="pause pending"} 0
@@ -1361,27 +1715,43 @@ windows_service_state{name="appvclient",state="unknown"} 0
 windows_service_state{name="appxsvc",state="continue pending"} 0
 windows_service_state{name="appxsvc",state="pause pending"} 0
 windows_service_state{name="appxsvc",state="paused"} 0
-windows_service_state{name="appxsvc",state="running"} 0
+windows_service_state{name="appxsvc",state="running"} 1
 windows_service_state{name="appxsvc",state="start pending"} 0
 windows_service_state{name="appxsvc",state="stop pending"} 0
-windows_service_state{name="appxsvc",state="stopped"} 1
+windows_service_state{name="appxsvc",state="stopped"} 0
 windows_service_state{name="appxsvc",state="unknown"} 0
+windows_service_state{name="assignedaccessmanagersvc",state="continue pending"} 0
+windows_service_state{name="assignedaccessmanagersvc",state="pause pending"} 0
+windows_service_state{name="assignedaccessmanagersvc",state="paused"} 0
+windows_service_state{name="assignedaccessmanagersvc",state="running"} 0
+windows_service_state{name="assignedaccessmanagersvc",state="start pending"} 0
+windows_service_state{name="assignedaccessmanagersvc",state="stop pending"} 0
+windows_service_state{name="assignedaccessmanagersvc",state="stopped"} 1
+windows_service_state{name="assignedaccessmanagersvc",state="unknown"} 0
 windows_service_state{name="audioendpointbuilder",state="continue pending"} 0
 windows_service_state{name="audioendpointbuilder",state="pause pending"} 0
 windows_service_state{name="audioendpointbuilder",state="paused"} 0
-windows_service_state{name="audioendpointbuilder",state="running"} 0
+windows_service_state{name="audioendpointbuilder",state="running"} 1
 windows_service_state{name="audioendpointbuilder",state="start pending"} 0
 windows_service_state{name="audioendpointbuilder",state="stop pending"} 0
-windows_service_state{name="audioendpointbuilder",state="stopped"} 1
+windows_service_state{name="audioendpointbuilder",state="stopped"} 0
 windows_service_state{name="audioendpointbuilder",state="unknown"} 0
 windows_service_state{name="audiosrv",state="continue pending"} 0
 windows_service_state{name="audiosrv",state="pause pending"} 0
 windows_service_state{name="audiosrv",state="paused"} 0
-windows_service_state{name="audiosrv",state="running"} 0
+windows_service_state{name="audiosrv",state="running"} 1
 windows_service_state{name="audiosrv",state="start pending"} 0
 windows_service_state{name="audiosrv",state="stop pending"} 0
-windows_service_state{name="audiosrv",state="stopped"} 1
+windows_service_state{name="audiosrv",state="stopped"} 0
 windows_service_state{name="audiosrv",state="unknown"} 0
+windows_service_state{name="autotimesvc",state="continue pending"} 0
+windows_service_state{name="autotimesvc",state="pause pending"} 0
+windows_service_state{name="autotimesvc",state="paused"} 0
+windows_service_state{name="autotimesvc",state="running"} 0
+windows_service_state{name="autotimesvc",state="start pending"} 0
+windows_service_state{name="autotimesvc",state="stop pending"} 0
+windows_service_state{name="autotimesvc",state="stopped"} 1
+windows_service_state{name="autotimesvc",state="unknown"} 0
 windows_service_state{name="axinstsv",state="continue pending"} 0
 windows_service_state{name="axinstsv",state="pause pending"} 0
 windows_service_state{name="axinstsv",state="paused"} 0
@@ -1390,6 +1760,22 @@ windows_service_state{name="axinstsv",state="start pending"} 0
 windows_service_state{name="axinstsv",state="stop pending"} 0
 windows_service_state{name="axinstsv",state="stopped"} 1
 windows_service_state{name="axinstsv",state="unknown"} 0
+windows_service_state{name="bcastdvruserservice_390e7",state="continue pending"} 0
+windows_service_state{name="bcastdvruserservice_390e7",state="pause pending"} 0
+windows_service_state{name="bcastdvruserservice_390e7",state="paused"} 0
+windows_service_state{name="bcastdvruserservice_390e7",state="running"} 0
+windows_service_state{name="bcastdvruserservice_390e7",state="start pending"} 0
+windows_service_state{name="bcastdvruserservice_390e7",state="stop pending"} 0
+windows_service_state{name="bcastdvruserservice_390e7",state="stopped"} 1
+windows_service_state{name="bcastdvruserservice_390e7",state="unknown"} 0
+windows_service_state{name="bdesvc",state="continue pending"} 0
+windows_service_state{name="bdesvc",state="pause pending"} 0
+windows_service_state{name="bdesvc",state="paused"} 0
+windows_service_state{name="bdesvc",state="running"} 0
+windows_service_state{name="bdesvc",state="start pending"} 0
+windows_service_state{name="bdesvc",state="stop pending"} 0
+windows_service_state{name="bdesvc",state="stopped"} 1
+windows_service_state{name="bdesvc",state="unknown"} 0
 windows_service_state{name="bfe",state="continue pending"} 0
 windows_service_state{name="bfe",state="pause pending"} 0
 windows_service_state{name="bfe",state="paused"} 0
@@ -1401,11 +1787,19 @@ windows_service_state{name="bfe",state="unknown"} 0
 windows_service_state{name="bits",state="continue pending"} 0
 windows_service_state{name="bits",state="pause pending"} 0
 windows_service_state{name="bits",state="paused"} 0
-windows_service_state{name="bits",state="running"} 0
+windows_service_state{name="bits",state="running"} 1
 windows_service_state{name="bits",state="start pending"} 0
 windows_service_state{name="bits",state="stop pending"} 0
-windows_service_state{name="bits",state="stopped"} 1
+windows_service_state{name="bits",state="stopped"} 0
 windows_service_state{name="bits",state="unknown"} 0
+windows_service_state{name="bluetoothuserservice_390e7",state="continue pending"} 0
+windows_service_state{name="bluetoothuserservice_390e7",state="pause pending"} 0
+windows_service_state{name="bluetoothuserservice_390e7",state="paused"} 0
+windows_service_state{name="bluetoothuserservice_390e7",state="running"} 0
+windows_service_state{name="bluetoothuserservice_390e7",state="start pending"} 0
+windows_service_state{name="bluetoothuserservice_390e7",state="stop pending"} 0
+windows_service_state{name="bluetoothuserservice_390e7",state="stopped"} 1
+windows_service_state{name="bluetoothuserservice_390e7",state="unknown"} 0
 windows_service_state{name="brokerinfrastructure",state="continue pending"} 0
 windows_service_state{name="brokerinfrastructure",state="pause pending"} 0
 windows_service_state{name="brokerinfrastructure",state="paused"} 0
@@ -1414,14 +1808,22 @@ windows_service_state{name="brokerinfrastructure",state="start pending"} 0
 windows_service_state{name="brokerinfrastructure",state="stop pending"} 0
 windows_service_state{name="brokerinfrastructure",state="stopped"} 0
 windows_service_state{name="brokerinfrastructure",state="unknown"} 0
-windows_service_state{name="browser",state="continue pending"} 0
-windows_service_state{name="browser",state="pause pending"} 0
-windows_service_state{name="browser",state="paused"} 0
-windows_service_state{name="browser",state="running"} 0
-windows_service_state{name="browser",state="start pending"} 0
-windows_service_state{name="browser",state="stop pending"} 0
-windows_service_state{name="browser",state="stopped"} 1
-windows_service_state{name="browser",state="unknown"} 0
+windows_service_state{name="btagservice",state="continue pending"} 0
+windows_service_state{name="btagservice",state="pause pending"} 0
+windows_service_state{name="btagservice",state="paused"} 0
+windows_service_state{name="btagservice",state="running"} 0
+windows_service_state{name="btagservice",state="start pending"} 0
+windows_service_state{name="btagservice",state="stop pending"} 0
+windows_service_state{name="btagservice",state="stopped"} 1
+windows_service_state{name="btagservice",state="unknown"} 0
+windows_service_state{name="bthavctpsvc",state="continue pending"} 0
+windows_service_state{name="bthavctpsvc",state="pause pending"} 0
+windows_service_state{name="bthavctpsvc",state="paused"} 0
+windows_service_state{name="bthavctpsvc",state="running"} 1
+windows_service_state{name="bthavctpsvc",state="start pending"} 0
+windows_service_state{name="bthavctpsvc",state="stop pending"} 0
+windows_service_state{name="bthavctpsvc",state="stopped"} 0
+windows_service_state{name="bthavctpsvc",state="unknown"} 0
 windows_service_state{name="bthserv",state="continue pending"} 0
 windows_service_state{name="bthserv",state="pause pending"} 0
 windows_service_state{name="bthserv",state="paused"} 0
@@ -1430,6 +1832,30 @@ windows_service_state{name="bthserv",state="start pending"} 0
 windows_service_state{name="bthserv",state="stop pending"} 0
 windows_service_state{name="bthserv",state="stopped"} 1
 windows_service_state{name="bthserv",state="unknown"} 0
+windows_service_state{name="camsvc",state="continue pending"} 0
+windows_service_state{name="camsvc",state="pause pending"} 0
+windows_service_state{name="camsvc",state="paused"} 0
+windows_service_state{name="camsvc",state="running"} 0
+windows_service_state{name="camsvc",state="start pending"} 0
+windows_service_state{name="camsvc",state="stop pending"} 0
+windows_service_state{name="camsvc",state="stopped"} 1
+windows_service_state{name="camsvc",state="unknown"} 0
+windows_service_state{name="captureservice_390e7",state="continue pending"} 0
+windows_service_state{name="captureservice_390e7",state="pause pending"} 0
+windows_service_state{name="captureservice_390e7",state="paused"} 0
+windows_service_state{name="captureservice_390e7",state="running"} 0
+windows_service_state{name="captureservice_390e7",state="start pending"} 0
+windows_service_state{name="captureservice_390e7",state="stop pending"} 0
+windows_service_state{name="captureservice_390e7",state="stopped"} 1
+windows_service_state{name="captureservice_390e7",state="unknown"} 0
+windows_service_state{name="cbdhsvc_390e7",state="continue pending"} 0
+windows_service_state{name="cbdhsvc_390e7",state="pause pending"} 0
+windows_service_state{name="cbdhsvc_390e7",state="paused"} 0
+windows_service_state{name="cbdhsvc_390e7",state="running"} 1
+windows_service_state{name="cbdhsvc_390e7",state="start pending"} 0
+windows_service_state{name="cbdhsvc_390e7",state="stop pending"} 0
+windows_service_state{name="cbdhsvc_390e7",state="stopped"} 0
+windows_service_state{name="cbdhsvc_390e7",state="unknown"} 0
 windows_service_state{name="cdpsvc",state="continue pending"} 0
 windows_service_state{name="cdpsvc",state="pause pending"} 0
 windows_service_state{name="cdpsvc",state="paused"} 0
@@ -1438,14 +1864,14 @@ windows_service_state{name="cdpsvc",state="start pending"} 0
 windows_service_state{name="cdpsvc",state="stop pending"} 0
 windows_service_state{name="cdpsvc",state="stopped"} 0
 windows_service_state{name="cdpsvc",state="unknown"} 0
-windows_service_state{name="cdpusersvc_225e3",state="continue pending"} 0
-windows_service_state{name="cdpusersvc_225e3",state="pause pending"} 0
-windows_service_state{name="cdpusersvc_225e3",state="paused"} 0
-windows_service_state{name="cdpusersvc_225e3",state="running"} 1
-windows_service_state{name="cdpusersvc_225e3",state="start pending"} 0
-windows_service_state{name="cdpusersvc_225e3",state="stop pending"} 0
-windows_service_state{name="cdpusersvc_225e3",state="stopped"} 0
-windows_service_state{name="cdpusersvc_225e3",state="unknown"} 0
+windows_service_state{name="cdpusersvc_390e7",state="continue pending"} 0
+windows_service_state{name="cdpusersvc_390e7",state="pause pending"} 0
+windows_service_state{name="cdpusersvc_390e7",state="paused"} 0
+windows_service_state{name="cdpusersvc_390e7",state="running"} 1
+windows_service_state{name="cdpusersvc_390e7",state="start pending"} 0
+windows_service_state{name="cdpusersvc_390e7",state="stop pending"} 0
+windows_service_state{name="cdpusersvc_390e7",state="stopped"} 0
+windows_service_state{name="cdpusersvc_390e7",state="unknown"} 0
 windows_service_state{name="certpropsvc",state="continue pending"} 0
 windows_service_state{name="certpropsvc",state="pause pending"} 0
 windows_service_state{name="certpropsvc",state="paused"} 0
@@ -1457,10 +1883,10 @@ windows_service_state{name="certpropsvc",state="unknown"} 0
 windows_service_state{name="clipsvc",state="continue pending"} 0
 windows_service_state{name="clipsvc",state="pause pending"} 0
 windows_service_state{name="clipsvc",state="paused"} 0
-windows_service_state{name="clipsvc",state="running"} 0
+windows_service_state{name="clipsvc",state="running"} 1
 windows_service_state{name="clipsvc",state="start pending"} 0
 windows_service_state{name="clipsvc",state="stop pending"} 0
-windows_service_state{name="clipsvc",state="stopped"} 1
+windows_service_state{name="clipsvc",state="stopped"} 0
 windows_service_state{name="clipsvc",state="unknown"} 0
 windows_service_state{name="comsysapp",state="continue pending"} 0
 windows_service_state{name="comsysapp",state="pause pending"} 0
@@ -1470,6 +1896,14 @@ windows_service_state{name="comsysapp",state="start pending"} 0
 windows_service_state{name="comsysapp",state="stop pending"} 0
 windows_service_state{name="comsysapp",state="stopped"} 1
 windows_service_state{name="comsysapp",state="unknown"} 0
+windows_service_state{name="consentuxusersvc_390e7",state="continue pending"} 0
+windows_service_state{name="consentuxusersvc_390e7",state="pause pending"} 0
+windows_service_state{name="consentuxusersvc_390e7",state="paused"} 0
+windows_service_state{name="consentuxusersvc_390e7",state="running"} 0
+windows_service_state{name="consentuxusersvc_390e7",state="start pending"} 0
+windows_service_state{name="consentuxusersvc_390e7",state="stop pending"} 0
+windows_service_state{name="consentuxusersvc_390e7",state="stopped"} 1
+windows_service_state{name="consentuxusersvc_390e7",state="unknown"} 0
 windows_service_state{name="coremessagingregistrar",state="continue pending"} 0
 windows_service_state{name="coremessagingregistrar",state="pause pending"} 0
 windows_service_state{name="coremessagingregistrar",state="paused"} 0
@@ -1478,6 +1912,14 @@ windows_service_state{name="coremessagingregistrar",state="start pending"} 0
 windows_service_state{name="coremessagingregistrar",state="stop pending"} 0
 windows_service_state{name="coremessagingregistrar",state="stopped"} 0
 windows_service_state{name="coremessagingregistrar",state="unknown"} 0
+windows_service_state{name="credentialenrollmentmanagerusersvc_390e7",state="continue pending"} 0
+windows_service_state{name="credentialenrollmentmanagerusersvc_390e7",state="pause pending"} 0
+windows_service_state{name="credentialenrollmentmanagerusersvc_390e7",state="paused"} 0
+windows_service_state{name="credentialenrollmentmanagerusersvc_390e7",state="running"} 0
+windows_service_state{name="credentialenrollmentmanagerusersvc_390e7",state="start pending"} 0
+windows_service_state{name="credentialenrollmentmanagerusersvc_390e7",state="stop pending"} 0
+windows_service_state{name="credentialenrollmentmanagerusersvc_390e7",state="stopped"} 1
+windows_service_state{name="credentialenrollmentmanagerusersvc_390e7",state="unknown"} 0
 windows_service_state{name="cryptsvc",state="continue pending"} 0
 windows_service_state{name="cryptsvc",state="pause pending"} 0
 windows_service_state{name="cryptsvc",state="paused"} 0
@@ -1502,14 +1944,6 @@ windows_service_state{name="dcomlaunch",state="start pending"} 0
 windows_service_state{name="dcomlaunch",state="stop pending"} 0
 windows_service_state{name="dcomlaunch",state="stopped"} 0
 windows_service_state{name="dcomlaunch",state="unknown"} 0
-windows_service_state{name="dcpsvc",state="continue pending"} 0
-windows_service_state{name="dcpsvc",state="pause pending"} 0
-windows_service_state{name="dcpsvc",state="paused"} 0
-windows_service_state{name="dcpsvc",state="running"} 0
-windows_service_state{name="dcpsvc",state="start pending"} 0
-windows_service_state{name="dcpsvc",state="stop pending"} 0
-windows_service_state{name="dcpsvc",state="stopped"} 1
-windows_service_state{name="dcpsvc",state="unknown"} 0
 windows_service_state{name="defragsvc",state="continue pending"} 0
 windows_service_state{name="defragsvc",state="pause pending"} 0
 windows_service_state{name="defragsvc",state="paused"} 0
@@ -1518,6 +1952,14 @@ windows_service_state{name="defragsvc",state="start pending"} 0
 windows_service_state{name="defragsvc",state="stop pending"} 0
 windows_service_state{name="defragsvc",state="stopped"} 1
 windows_service_state{name="defragsvc",state="unknown"} 0
+windows_service_state{name="deviceassociationbrokersvc_390e7",state="continue pending"} 0
+windows_service_state{name="deviceassociationbrokersvc_390e7",state="pause pending"} 0
+windows_service_state{name="deviceassociationbrokersvc_390e7",state="paused"} 0
+windows_service_state{name="deviceassociationbrokersvc_390e7",state="running"} 0
+windows_service_state{name="deviceassociationbrokersvc_390e7",state="start pending"} 0
+windows_service_state{name="deviceassociationbrokersvc_390e7",state="stop pending"} 0
+windows_service_state{name="deviceassociationbrokersvc_390e7",state="stopped"} 1
+windows_service_state{name="deviceassociationbrokersvc_390e7",state="unknown"} 0
 windows_service_state{name="deviceassociationservice",state="continue pending"} 0
 windows_service_state{name="deviceassociationservice",state="pause pending"} 0
 windows_service_state{name="deviceassociationservice",state="paused"} 0
@@ -1534,6 +1976,22 @@ windows_service_state{name="deviceinstall",state="start pending"} 0
 windows_service_state{name="deviceinstall",state="stop pending"} 0
 windows_service_state{name="deviceinstall",state="stopped"} 1
 windows_service_state{name="deviceinstall",state="unknown"} 0
+windows_service_state{name="devicepickerusersvc_390e7",state="continue pending"} 0
+windows_service_state{name="devicepickerusersvc_390e7",state="pause pending"} 0
+windows_service_state{name="devicepickerusersvc_390e7",state="paused"} 0
+windows_service_state{name="devicepickerusersvc_390e7",state="running"} 0
+windows_service_state{name="devicepickerusersvc_390e7",state="start pending"} 0
+windows_service_state{name="devicepickerusersvc_390e7",state="stop pending"} 0
+windows_service_state{name="devicepickerusersvc_390e7",state="stopped"} 1
+windows_service_state{name="devicepickerusersvc_390e7",state="unknown"} 0
+windows_service_state{name="devicesflowusersvc_390e7",state="continue pending"} 0
+windows_service_state{name="devicesflowusersvc_390e7",state="pause pending"} 0
+windows_service_state{name="devicesflowusersvc_390e7",state="paused"} 0
+windows_service_state{name="devicesflowusersvc_390e7",state="running"} 0
+windows_service_state{name="devicesflowusersvc_390e7",state="start pending"} 0
+windows_service_state{name="devicesflowusersvc_390e7",state="stop pending"} 0
+windows_service_state{name="devicesflowusersvc_390e7",state="stopped"} 1
+windows_service_state{name="devicesflowusersvc_390e7",state="unknown"} 0
 windows_service_state{name="devquerybroker",state="continue pending"} 0
 windows_service_state{name="devquerybroker",state="pause pending"} 0
 windows_service_state{name="devquerybroker",state="paused"} 0
@@ -1558,6 +2016,14 @@ windows_service_state{name="diagnosticshub.standardcollector.service",state="sta
 windows_service_state{name="diagnosticshub.standardcollector.service",state="stop pending"} 0
 windows_service_state{name="diagnosticshub.standardcollector.service",state="stopped"} 1
 windows_service_state{name="diagnosticshub.standardcollector.service",state="unknown"} 0
+windows_service_state{name="diagsvc",state="continue pending"} 0
+windows_service_state{name="diagsvc",state="pause pending"} 0
+windows_service_state{name="diagsvc",state="paused"} 0
+windows_service_state{name="diagsvc",state="running"} 0
+windows_service_state{name="diagsvc",state="start pending"} 0
+windows_service_state{name="diagsvc",state="stop pending"} 0
+windows_service_state{name="diagsvc",state="stopped"} 1
+windows_service_state{name="diagsvc",state="unknown"} 0
 windows_service_state{name="diagtrack",state="continue pending"} 0
 windows_service_state{name="diagtrack",state="pause pending"} 0
 windows_service_state{name="diagtrack",state="paused"} 0
@@ -1566,6 +2032,22 @@ windows_service_state{name="diagtrack",state="start pending"} 0
 windows_service_state{name="diagtrack",state="stop pending"} 0
 windows_service_state{name="diagtrack",state="stopped"} 0
 windows_service_state{name="diagtrack",state="unknown"} 0
+windows_service_state{name="dispbrokerdesktopsvc",state="continue pending"} 0
+windows_service_state{name="dispbrokerdesktopsvc",state="pause pending"} 0
+windows_service_state{name="dispbrokerdesktopsvc",state="paused"} 0
+windows_service_state{name="dispbrokerdesktopsvc",state="running"} 1
+windows_service_state{name="dispbrokerdesktopsvc",state="start pending"} 0
+windows_service_state{name="dispbrokerdesktopsvc",state="stop pending"} 0
+windows_service_state{name="dispbrokerdesktopsvc",state="stopped"} 0
+windows_service_state{name="dispbrokerdesktopsvc",state="unknown"} 0
+windows_service_state{name="displayenhancementservice",state="continue pending"} 0
+windows_service_state{name="displayenhancementservice",state="pause pending"} 0
+windows_service_state{name="displayenhancementservice",state="paused"} 0
+windows_service_state{name="displayenhancementservice",state="running"} 0
+windows_service_state{name="displayenhancementservice",state="start pending"} 0
+windows_service_state{name="displayenhancementservice",state="stop pending"} 0
+windows_service_state{name="displayenhancementservice",state="stopped"} 1
+windows_service_state{name="displayenhancementservice",state="unknown"} 0
 windows_service_state{name="dmenrollmentsvc",state="continue pending"} 0
 windows_service_state{name="dmenrollmentsvc",state="pause pending"} 0
 windows_service_state{name="dmenrollmentsvc",state="paused"} 0
@@ -1590,6 +2072,14 @@ windows_service_state{name="dnscache",state="start pending"} 0
 windows_service_state{name="dnscache",state="stop pending"} 0
 windows_service_state{name="dnscache",state="stopped"} 0
 windows_service_state{name="dnscache",state="unknown"} 0
+windows_service_state{name="dosvc",state="continue pending"} 0
+windows_service_state{name="dosvc",state="pause pending"} 0
+windows_service_state{name="dosvc",state="paused"} 0
+windows_service_state{name="dosvc",state="running"} 1
+windows_service_state{name="dosvc",state="start pending"} 0
+windows_service_state{name="dosvc",state="stop pending"} 0
+windows_service_state{name="dosvc",state="stopped"} 0
+windows_service_state{name="dosvc",state="unknown"} 0
 windows_service_state{name="dot3svc",state="continue pending"} 0
 windows_service_state{name="dot3svc",state="pause pending"} 0
 windows_service_state{name="dot3svc",state="paused"} 0
@@ -1617,11 +2107,19 @@ windows_service_state{name="dsmsvc",state="unknown"} 0
 windows_service_state{name="dssvc",state="continue pending"} 0
 windows_service_state{name="dssvc",state="pause pending"} 0
 windows_service_state{name="dssvc",state="paused"} 0
-windows_service_state{name="dssvc",state="running"} 0
+windows_service_state{name="dssvc",state="running"} 1
 windows_service_state{name="dssvc",state="start pending"} 0
 windows_service_state{name="dssvc",state="stop pending"} 0
-windows_service_state{name="dssvc",state="stopped"} 1
+windows_service_state{name="dssvc",state="stopped"} 0
 windows_service_state{name="dssvc",state="unknown"} 0
+windows_service_state{name="dusmsvc",state="continue pending"} 0
+windows_service_state{name="dusmsvc",state="pause pending"} 0
+windows_service_state{name="dusmsvc",state="paused"} 0
+windows_service_state{name="dusmsvc",state="running"} 1
+windows_service_state{name="dusmsvc",state="start pending"} 0
+windows_service_state{name="dusmsvc",state="stop pending"} 0
+windows_service_state{name="dusmsvc",state="stopped"} 0
+windows_service_state{name="dusmsvc",state="unknown"} 0
 windows_service_state{name="eaphost",state="continue pending"} 0
 windows_service_state{name="eaphost",state="pause pending"} 0
 windows_service_state{name="eaphost",state="paused"} 0
@@ -1670,13 +2168,21 @@ windows_service_state{name="eventsystem",state="start pending"} 0
 windows_service_state{name="eventsystem",state="stop pending"} 0
 windows_service_state{name="eventsystem",state="stopped"} 0
 windows_service_state{name="eventsystem",state="unknown"} 0
+windows_service_state{name="fax",state="continue pending"} 0
+windows_service_state{name="fax",state="pause pending"} 0
+windows_service_state{name="fax",state="paused"} 0
+windows_service_state{name="fax",state="running"} 0
+windows_service_state{name="fax",state="start pending"} 0
+windows_service_state{name="fax",state="stop pending"} 0
+windows_service_state{name="fax",state="stopped"} 1
+windows_service_state{name="fax",state="unknown"} 0
 windows_service_state{name="fdphost",state="continue pending"} 0
 windows_service_state{name="fdphost",state="pause pending"} 0
 windows_service_state{name="fdphost",state="paused"} 0
-windows_service_state{name="fdphost",state="running"} 1
+windows_service_state{name="fdphost",state="running"} 0
 windows_service_state{name="fdphost",state="start pending"} 0
 windows_service_state{name="fdphost",state="stop pending"} 0
-windows_service_state{name="fdphost",state="stopped"} 0
+windows_service_state{name="fdphost",state="stopped"} 1
 windows_service_state{name="fdphost",state="unknown"} 0
 windows_service_state{name="fdrespub",state="continue pending"} 0
 windows_service_state{name="fdrespub",state="pause pending"} 0
@@ -1686,6 +2192,14 @@ windows_service_state{name="fdrespub",state="start pending"} 0
 windows_service_state{name="fdrespub",state="stop pending"} 0
 windows_service_state{name="fdrespub",state="stopped"} 1
 windows_service_state{name="fdrespub",state="unknown"} 0
+windows_service_state{name="fhsvc",state="continue pending"} 0
+windows_service_state{name="fhsvc",state="pause pending"} 0
+windows_service_state{name="fhsvc",state="paused"} 0
+windows_service_state{name="fhsvc",state="running"} 0
+windows_service_state{name="fhsvc",state="start pending"} 0
+windows_service_state{name="fhsvc",state="stop pending"} 0
+windows_service_state{name="fhsvc",state="stopped"} 1
+windows_service_state{name="fhsvc",state="unknown"} 0
 windows_service_state{name="fontcache",state="continue pending"} 0
 windows_service_state{name="fontcache",state="pause pending"} 0
 windows_service_state{name="fontcache",state="paused"} 0
@@ -1694,6 +2208,14 @@ windows_service_state{name="fontcache",state="start pending"} 0
 windows_service_state{name="fontcache",state="stop pending"} 0
 windows_service_state{name="fontcache",state="stopped"} 0
 windows_service_state{name="fontcache",state="unknown"} 0
+windows_service_state{name="fontcache3.0.0.0",state="continue pending"} 0
+windows_service_state{name="fontcache3.0.0.0",state="pause pending"} 0
+windows_service_state{name="fontcache3.0.0.0",state="paused"} 0
+windows_service_state{name="fontcache3.0.0.0",state="running"} 0
+windows_service_state{name="fontcache3.0.0.0",state="start pending"} 0
+windows_service_state{name="fontcache3.0.0.0",state="stop pending"} 0
+windows_service_state{name="fontcache3.0.0.0",state="stopped"} 1
+windows_service_state{name="fontcache3.0.0.0",state="unknown"} 0
 windows_service_state{name="frameserver",state="continue pending"} 0
 windows_service_state{name="frameserver",state="pause pending"} 0
 windows_service_state{name="frameserver",state="paused"} 0
@@ -1705,11 +2227,19 @@ windows_service_state{name="frameserver",state="unknown"} 0
 windows_service_state{name="gpsvc",state="continue pending"} 0
 windows_service_state{name="gpsvc",state="pause pending"} 0
 windows_service_state{name="gpsvc",state="paused"} 0
-windows_service_state{name="gpsvc",state="running"} 1
+windows_service_state{name="gpsvc",state="running"} 0
 windows_service_state{name="gpsvc",state="start pending"} 0
 windows_service_state{name="gpsvc",state="stop pending"} 0
-windows_service_state{name="gpsvc",state="stopped"} 0
+windows_service_state{name="gpsvc",state="stopped"} 1
 windows_service_state{name="gpsvc",state="unknown"} 0
+windows_service_state{name="graphicsperfsvc",state="continue pending"} 0
+windows_service_state{name="graphicsperfsvc",state="pause pending"} 0
+windows_service_state{name="graphicsperfsvc",state="paused"} 0
+windows_service_state{name="graphicsperfsvc",state="running"} 0
+windows_service_state{name="graphicsperfsvc",state="start pending"} 0
+windows_service_state{name="graphicsperfsvc",state="stop pending"} 0
+windows_service_state{name="graphicsperfsvc",state="stopped"} 1
+windows_service_state{name="graphicsperfsvc",state="unknown"} 0
 windows_service_state{name="hidserv",state="continue pending"} 0
 windows_service_state{name="hidserv",state="pause pending"} 0
 windows_service_state{name="hidserv",state="paused"} 0
@@ -1737,11 +2267,19 @@ windows_service_state{name="icssvc",state="unknown"} 0
 windows_service_state{name="ikeext",state="continue pending"} 0
 windows_service_state{name="ikeext",state="pause pending"} 0
 windows_service_state{name="ikeext",state="paused"} 0
-windows_service_state{name="ikeext",state="running"} 1
+windows_service_state{name="ikeext",state="running"} 0
 windows_service_state{name="ikeext",state="start pending"} 0
 windows_service_state{name="ikeext",state="stop pending"} 0
-windows_service_state{name="ikeext",state="stopped"} 0
+windows_service_state{name="ikeext",state="stopped"} 1
 windows_service_state{name="ikeext",state="unknown"} 0
+windows_service_state{name="installservice",state="continue pending"} 0
+windows_service_state{name="installservice",state="pause pending"} 0
+windows_service_state{name="installservice",state="paused"} 0
+windows_service_state{name="installservice",state="running"} 1
+windows_service_state{name="installservice",state="start pending"} 0
+windows_service_state{name="installservice",state="stop pending"} 0
+windows_service_state{name="installservice",state="stopped"} 0
+windows_service_state{name="installservice",state="unknown"} 0
 windows_service_state{name="iphlpsvc",state="continue pending"} 0
 windows_service_state{name="iphlpsvc",state="pause pending"} 0
 windows_service_state{name="iphlpsvc",state="paused"} 0
@@ -1750,6 +2288,22 @@ windows_service_state{name="iphlpsvc",state="start pending"} 0
 windows_service_state{name="iphlpsvc",state="stop pending"} 0
 windows_service_state{name="iphlpsvc",state="stopped"} 0
 windows_service_state{name="iphlpsvc",state="unknown"} 0
+windows_service_state{name="ipoverusbsvc",state="continue pending"} 0
+windows_service_state{name="ipoverusbsvc",state="pause pending"} 0
+windows_service_state{name="ipoverusbsvc",state="paused"} 0
+windows_service_state{name="ipoverusbsvc",state="running"} 1
+windows_service_state{name="ipoverusbsvc",state="start pending"} 0
+windows_service_state{name="ipoverusbsvc",state="stop pending"} 0
+windows_service_state{name="ipoverusbsvc",state="stopped"} 0
+windows_service_state{name="ipoverusbsvc",state="unknown"} 0
+windows_service_state{name="ipxlatcfgsvc",state="continue pending"} 0
+windows_service_state{name="ipxlatcfgsvc",state="pause pending"} 0
+windows_service_state{name="ipxlatcfgsvc",state="paused"} 0
+windows_service_state{name="ipxlatcfgsvc",state="running"} 0
+windows_service_state{name="ipxlatcfgsvc",state="start pending"} 0
+windows_service_state{name="ipxlatcfgsvc",state="stop pending"} 0
+windows_service_state{name="ipxlatcfgsvc",state="stopped"} 1
+windows_service_state{name="ipxlatcfgsvc",state="unknown"} 0
 windows_service_state{name="keyiso",state="continue pending"} 0
 windows_service_state{name="keyiso",state="pause pending"} 0
 windows_service_state{name="keyiso",state="paused"} 0
@@ -1758,14 +2312,6 @@ windows_service_state{name="keyiso",state="start pending"} 0
 windows_service_state{name="keyiso",state="stop pending"} 0
 windows_service_state{name="keyiso",state="stopped"} 0
 windows_service_state{name="keyiso",state="unknown"} 0
-windows_service_state{name="kpssvc",state="continue pending"} 0
-windows_service_state{name="kpssvc",state="pause pending"} 0
-windows_service_state{name="kpssvc",state="paused"} 0
-windows_service_state{name="kpssvc",state="running"} 0
-windows_service_state{name="kpssvc",state="start pending"} 0
-windows_service_state{name="kpssvc",state="stop pending"} 0
-windows_service_state{name="kpssvc",state="stopped"} 1
-windows_service_state{name="kpssvc",state="unknown"} 0
 windows_service_state{name="ktmrm",state="continue pending"} 0
 windows_service_state{name="ktmrm",state="pause pending"} 0
 windows_service_state{name="ktmrm",state="paused"} 0
@@ -1801,10 +2347,10 @@ windows_service_state{name="lfsvc",state="unknown"} 0
 windows_service_state{name="licensemanager",state="continue pending"} 0
 windows_service_state{name="licensemanager",state="pause pending"} 0
 windows_service_state{name="licensemanager",state="paused"} 0
-windows_service_state{name="licensemanager",state="running"} 0
+windows_service_state{name="licensemanager",state="running"} 1
 windows_service_state{name="licensemanager",state="start pending"} 0
 windows_service_state{name="licensemanager",state="stop pending"} 0
-windows_service_state{name="licensemanager",state="stopped"} 1
+windows_service_state{name="licensemanager",state="stopped"} 0
 windows_service_state{name="licensemanager",state="unknown"} 0
 windows_service_state{name="lltdsvc",state="continue pending"} 0
 windows_service_state{name="lltdsvc",state="pause pending"} 0
@@ -1830,6 +2376,14 @@ windows_service_state{name="lsm",state="start pending"} 0
 windows_service_state{name="lsm",state="stop pending"} 0
 windows_service_state{name="lsm",state="stopped"} 0
 windows_service_state{name="lsm",state="unknown"} 0
+windows_service_state{name="lxpsvc",state="continue pending"} 0
+windows_service_state{name="lxpsvc",state="pause pending"} 0
+windows_service_state{name="lxpsvc",state="paused"} 0
+windows_service_state{name="lxpsvc",state="running"} 0
+windows_service_state{name="lxpsvc",state="start pending"} 0
+windows_service_state{name="lxpsvc",state="stop pending"} 0
+windows_service_state{name="lxpsvc",state="stopped"} 1
+windows_service_state{name="lxpsvc",state="unknown"} 0
 windows_service_state{name="mapsbroker",state="continue pending"} 0
 windows_service_state{name="mapsbroker",state="pause pending"} 0
 windows_service_state{name="mapsbroker",state="paused"} 0
@@ -1838,6 +2392,30 @@ windows_service_state{name="mapsbroker",state="start pending"} 0
 windows_service_state{name="mapsbroker",state="stop pending"} 0
 windows_service_state{name="mapsbroker",state="stopped"} 1
 windows_service_state{name="mapsbroker",state="unknown"} 0
+windows_service_state{name="messagingservice_390e7",state="continue pending"} 0
+windows_service_state{name="messagingservice_390e7",state="pause pending"} 0
+windows_service_state{name="messagingservice_390e7",state="paused"} 0
+windows_service_state{name="messagingservice_390e7",state="running"} 0
+windows_service_state{name="messagingservice_390e7",state="start pending"} 0
+windows_service_state{name="messagingservice_390e7",state="stop pending"} 0
+windows_service_state{name="messagingservice_390e7",state="stopped"} 1
+windows_service_state{name="messagingservice_390e7",state="unknown"} 0
+windows_service_state{name="mixedrealityopenxrsvc",state="continue pending"} 0
+windows_service_state{name="mixedrealityopenxrsvc",state="pause pending"} 0
+windows_service_state{name="mixedrealityopenxrsvc",state="paused"} 0
+windows_service_state{name="mixedrealityopenxrsvc",state="running"} 0
+windows_service_state{name="mixedrealityopenxrsvc",state="start pending"} 0
+windows_service_state{name="mixedrealityopenxrsvc",state="stop pending"} 0
+windows_service_state{name="mixedrealityopenxrsvc",state="stopped"} 1
+windows_service_state{name="mixedrealityopenxrsvc",state="unknown"} 0
+windows_service_state{name="mozillamaintenance",state="continue pending"} 0
+windows_service_state{name="mozillamaintenance",state="pause pending"} 0
+windows_service_state{name="mozillamaintenance",state="paused"} 0
+windows_service_state{name="mozillamaintenance",state="running"} 0
+windows_service_state{name="mozillamaintenance",state="start pending"} 0
+windows_service_state{name="mozillamaintenance",state="stop pending"} 0
+windows_service_state{name="mozillamaintenance",state="stopped"} 1
+windows_service_state{name="mozillamaintenance",state="unknown"} 0
 windows_service_state{name="mpssvc",state="continue pending"} 0
 windows_service_state{name="mpssvc",state="pause pending"} 0
 windows_service_state{name="mpssvc",state="paused"} 0
@@ -1849,10 +2427,10 @@ windows_service_state{name="mpssvc",state="unknown"} 0
 windows_service_state{name="msdtc",state="continue pending"} 0
 windows_service_state{name="msdtc",state="pause pending"} 0
 windows_service_state{name="msdtc",state="paused"} 0
-windows_service_state{name="msdtc",state="running"} 1
+windows_service_state{name="msdtc",state="running"} 0
 windows_service_state{name="msdtc",state="start pending"} 0
 windows_service_state{name="msdtc",state="stop pending"} 0
-windows_service_state{name="msdtc",state="stopped"} 0
+windows_service_state{name="msdtc",state="stopped"} 1
 windows_service_state{name="msdtc",state="unknown"} 0
 windows_service_state{name="msiscsi",state="continue pending"} 0
 windows_service_state{name="msiscsi",state="pause pending"} 0
@@ -1870,6 +2448,14 @@ windows_service_state{name="msiserver",state="start pending"} 0
 windows_service_state{name="msiserver",state="stop pending"} 0
 windows_service_state{name="msiserver",state="stopped"} 1
 windows_service_state{name="msiserver",state="unknown"} 0
+windows_service_state{name="naturalauthentication",state="continue pending"} 0
+windows_service_state{name="naturalauthentication",state="pause pending"} 0
+windows_service_state{name="naturalauthentication",state="paused"} 0
+windows_service_state{name="naturalauthentication",state="running"} 0
+windows_service_state{name="naturalauthentication",state="start pending"} 0
+windows_service_state{name="naturalauthentication",state="stop pending"} 0
+windows_service_state{name="naturalauthentication",state="stopped"} 1
+windows_service_state{name="naturalauthentication",state="unknown"} 0
 windows_service_state{name="ncasvc",state="continue pending"} 0
 windows_service_state{name="ncasvc",state="pause pending"} 0
 windows_service_state{name="ncasvc",state="paused"} 0
@@ -1886,6 +2472,14 @@ windows_service_state{name="ncbservice",state="start pending"} 0
 windows_service_state{name="ncbservice",state="stop pending"} 0
 windows_service_state{name="ncbservice",state="stopped"} 0
 windows_service_state{name="ncbservice",state="unknown"} 0
+windows_service_state{name="ncdautosetup",state="continue pending"} 0
+windows_service_state{name="ncdautosetup",state="pause pending"} 0
+windows_service_state{name="ncdautosetup",state="paused"} 0
+windows_service_state{name="ncdautosetup",state="running"} 0
+windows_service_state{name="ncdautosetup",state="start pending"} 0
+windows_service_state{name="ncdautosetup",state="stop pending"} 0
+windows_service_state{name="ncdautosetup",state="stopped"} 1
+windows_service_state{name="ncdautosetup",state="unknown"} 0
 windows_service_state{name="netlogon",state="continue pending"} 0
 windows_service_state{name="netlogon",state="pause pending"} 0
 windows_service_state{name="netlogon",state="paused"} 0
@@ -1929,10 +2523,10 @@ windows_service_state{name="nettcpportsharing",state="unknown"} 0
 windows_service_state{name="newrelic-infra",state="continue pending"} 0
 windows_service_state{name="newrelic-infra",state="pause pending"} 0
 windows_service_state{name="newrelic-infra",state="paused"} 0
-windows_service_state{name="newrelic-infra",state="running"} 1
+windows_service_state{name="newrelic-infra",state="running"} 0
 windows_service_state{name="newrelic-infra",state="start pending"} 0
 windows_service_state{name="newrelic-infra",state="stop pending"} 0
-windows_service_state{name="newrelic-infra",state="stopped"} 0
+windows_service_state{name="newrelic-infra",state="stopped"} 1
 windows_service_state{name="newrelic-infra",state="unknown"} 0
 windows_service_state{name="ngcctnrsvc",state="continue pending"} 0
 windows_service_state{name="ngcctnrsvc",state="pause pending"} 0
@@ -1966,14 +2560,30 @@ windows_service_state{name="nsi",state="start pending"} 0
 windows_service_state{name="nsi",state="stop pending"} 0
 windows_service_state{name="nsi",state="stopped"} 0
 windows_service_state{name="nsi",state="unknown"} 0
-windows_service_state{name="onesyncsvc_225e3",state="continue pending"} 0
-windows_service_state{name="onesyncsvc_225e3",state="pause pending"} 0
-windows_service_state{name="onesyncsvc_225e3",state="paused"} 0
-windows_service_state{name="onesyncsvc_225e3",state="running"} 1
-windows_service_state{name="onesyncsvc_225e3",state="start pending"} 0
-windows_service_state{name="onesyncsvc_225e3",state="stop pending"} 0
-windows_service_state{name="onesyncsvc_225e3",state="stopped"} 0
-windows_service_state{name="onesyncsvc_225e3",state="unknown"} 0
+windows_service_state{name="onesyncsvc_390e7",state="continue pending"} 0
+windows_service_state{name="onesyncsvc_390e7",state="pause pending"} 0
+windows_service_state{name="onesyncsvc_390e7",state="paused"} 0
+windows_service_state{name="onesyncsvc_390e7",state="running"} 1
+windows_service_state{name="onesyncsvc_390e7",state="start pending"} 0
+windows_service_state{name="onesyncsvc_390e7",state="stop pending"} 0
+windows_service_state{name="onesyncsvc_390e7",state="stopped"} 0
+windows_service_state{name="onesyncsvc_390e7",state="unknown"} 0
+windows_service_state{name="p2pimsvc",state="continue pending"} 0
+windows_service_state{name="p2pimsvc",state="pause pending"} 0
+windows_service_state{name="p2pimsvc",state="paused"} 0
+windows_service_state{name="p2pimsvc",state="running"} 0
+windows_service_state{name="p2pimsvc",state="start pending"} 0
+windows_service_state{name="p2pimsvc",state="stop pending"} 0
+windows_service_state{name="p2pimsvc",state="stopped"} 1
+windows_service_state{name="p2pimsvc",state="unknown"} 0
+windows_service_state{name="p2psvc",state="continue pending"} 0
+windows_service_state{name="p2psvc",state="pause pending"} 0
+windows_service_state{name="p2psvc",state="paused"} 0
+windows_service_state{name="p2psvc",state="running"} 0
+windows_service_state{name="p2psvc",state="start pending"} 0
+windows_service_state{name="p2psvc",state="stop pending"} 0
+windows_service_state{name="p2psvc",state="stopped"} 1
+windows_service_state{name="p2psvc",state="unknown"} 0
 windows_service_state{name="pcasvc",state="continue pending"} 0
 windows_service_state{name="pcasvc",state="pause pending"} 0
 windows_service_state{name="pcasvc",state="paused"} 0
@@ -1982,6 +2592,22 @@ windows_service_state{name="pcasvc",state="start pending"} 0
 windows_service_state{name="pcasvc",state="stop pending"} 0
 windows_service_state{name="pcasvc",state="stopped"} 0
 windows_service_state{name="pcasvc",state="unknown"} 0
+windows_service_state{name="peerdistsvc",state="continue pending"} 0
+windows_service_state{name="peerdistsvc",state="pause pending"} 0
+windows_service_state{name="peerdistsvc",state="paused"} 0
+windows_service_state{name="peerdistsvc",state="running"} 0
+windows_service_state{name="peerdistsvc",state="start pending"} 0
+windows_service_state{name="peerdistsvc",state="stop pending"} 0
+windows_service_state{name="peerdistsvc",state="stopped"} 1
+windows_service_state{name="peerdistsvc",state="unknown"} 0
+windows_service_state{name="perceptionsimulation",state="continue pending"} 0
+windows_service_state{name="perceptionsimulation",state="pause pending"} 0
+windows_service_state{name="perceptionsimulation",state="paused"} 0
+windows_service_state{name="perceptionsimulation",state="running"} 0
+windows_service_state{name="perceptionsimulation",state="start pending"} 0
+windows_service_state{name="perceptionsimulation",state="stop pending"} 0
+windows_service_state{name="perceptionsimulation",state="stopped"} 1
+windows_service_state{name="perceptionsimulation",state="unknown"} 0
 windows_service_state{name="perfhost",state="continue pending"} 0
 windows_service_state{name="perfhost",state="pause pending"} 0
 windows_service_state{name="perfhost",state="paused"} 0
@@ -1998,14 +2624,14 @@ windows_service_state{name="phonesvc",state="start pending"} 0
 windows_service_state{name="phonesvc",state="stop pending"} 0
 windows_service_state{name="phonesvc",state="stopped"} 1
 windows_service_state{name="phonesvc",state="unknown"} 0
-windows_service_state{name="pimindexmaintenancesvc_225e3",state="continue pending"} 0
-windows_service_state{name="pimindexmaintenancesvc_225e3",state="pause pending"} 0
-windows_service_state{name="pimindexmaintenancesvc_225e3",state="paused"} 0
-windows_service_state{name="pimindexmaintenancesvc_225e3",state="running"} 0
-windows_service_state{name="pimindexmaintenancesvc_225e3",state="start pending"} 0
-windows_service_state{name="pimindexmaintenancesvc_225e3",state="stop pending"} 0
-windows_service_state{name="pimindexmaintenancesvc_225e3",state="stopped"} 1
-windows_service_state{name="pimindexmaintenancesvc_225e3",state="unknown"} 0
+windows_service_state{name="pimindexmaintenancesvc_390e7",state="continue pending"} 0
+windows_service_state{name="pimindexmaintenancesvc_390e7",state="pause pending"} 0
+windows_service_state{name="pimindexmaintenancesvc_390e7",state="paused"} 0
+windows_service_state{name="pimindexmaintenancesvc_390e7",state="running"} 0
+windows_service_state{name="pimindexmaintenancesvc_390e7",state="start pending"} 0
+windows_service_state{name="pimindexmaintenancesvc_390e7",state="stop pending"} 0
+windows_service_state{name="pimindexmaintenancesvc_390e7",state="stopped"} 1
+windows_service_state{name="pimindexmaintenancesvc_390e7",state="unknown"} 0
 windows_service_state{name="pla",state="continue pending"} 0
 windows_service_state{name="pla",state="pause pending"} 0
 windows_service_state{name="pla",state="paused"} 0
@@ -2022,13 +2648,29 @@ windows_service_state{name="plugplay",state="start pending"} 0
 windows_service_state{name="plugplay",state="stop pending"} 0
 windows_service_state{name="plugplay",state="stopped"} 0
 windows_service_state{name="plugplay",state="unknown"} 0
+windows_service_state{name="pnrpautoreg",state="continue pending"} 0
+windows_service_state{name="pnrpautoreg",state="pause pending"} 0
+windows_service_state{name="pnrpautoreg",state="paused"} 0
+windows_service_state{name="pnrpautoreg",state="running"} 0
+windows_service_state{name="pnrpautoreg",state="start pending"} 0
+windows_service_state{name="pnrpautoreg",state="stop pending"} 0
+windows_service_state{name="pnrpautoreg",state="stopped"} 1
+windows_service_state{name="pnrpautoreg",state="unknown"} 0
+windows_service_state{name="pnrpsvc",state="continue pending"} 0
+windows_service_state{name="pnrpsvc",state="pause pending"} 0
+windows_service_state{name="pnrpsvc",state="paused"} 0
+windows_service_state{name="pnrpsvc",state="running"} 0
+windows_service_state{name="pnrpsvc",state="start pending"} 0
+windows_service_state{name="pnrpsvc",state="stop pending"} 0
+windows_service_state{name="pnrpsvc",state="stopped"} 1
+windows_service_state{name="pnrpsvc",state="unknown"} 0
 windows_service_state{name="policyagent",state="continue pending"} 0
 windows_service_state{name="policyagent",state="pause pending"} 0
 windows_service_state{name="policyagent",state="paused"} 0
-windows_service_state{name="policyagent",state="running"} 1
+windows_service_state{name="policyagent",state="running"} 0
 windows_service_state{name="policyagent",state="start pending"} 0
 windows_service_state{name="policyagent",state="stop pending"} 0
-windows_service_state{name="policyagent",state="stopped"} 0
+windows_service_state{name="policyagent",state="stopped"} 1
 windows_service_state{name="policyagent",state="unknown"} 0
 windows_service_state{name="power",state="continue pending"} 0
 windows_service_state{name="power",state="pause pending"} 0
@@ -2046,6 +2688,14 @@ windows_service_state{name="printnotify",state="start pending"} 0
 windows_service_state{name="printnotify",state="stop pending"} 0
 windows_service_state{name="printnotify",state="stopped"} 1
 windows_service_state{name="printnotify",state="unknown"} 0
+windows_service_state{name="printworkflowusersvc_390e7",state="continue pending"} 0
+windows_service_state{name="printworkflowusersvc_390e7",state="pause pending"} 0
+windows_service_state{name="printworkflowusersvc_390e7",state="paused"} 0
+windows_service_state{name="printworkflowusersvc_390e7",state="running"} 0
+windows_service_state{name="printworkflowusersvc_390e7",state="start pending"} 0
+windows_service_state{name="printworkflowusersvc_390e7",state="stop pending"} 0
+windows_service_state{name="printworkflowusersvc_390e7",state="stopped"} 1
+windows_service_state{name="printworkflowusersvc_390e7",state="unknown"} 0
 windows_service_state{name="profsvc",state="continue pending"} 0
 windows_service_state{name="profsvc",state="pause pending"} 0
 windows_service_state{name="profsvc",state="paused"} 0
@@ -2054,6 +2704,14 @@ windows_service_state{name="profsvc",state="start pending"} 0
 windows_service_state{name="profsvc",state="stop pending"} 0
 windows_service_state{name="profsvc",state="stopped"} 0
 windows_service_state{name="profsvc",state="unknown"} 0
+windows_service_state{name="pushtoinstall",state="continue pending"} 0
+windows_service_state{name="pushtoinstall",state="pause pending"} 0
+windows_service_state{name="pushtoinstall",state="paused"} 0
+windows_service_state{name="pushtoinstall",state="running"} 0
+windows_service_state{name="pushtoinstall",state="start pending"} 0
+windows_service_state{name="pushtoinstall",state="stop pending"} 0
+windows_service_state{name="pushtoinstall",state="stopped"} 1
+windows_service_state{name="pushtoinstall",state="unknown"} 0
 windows_service_state{name="qwave",state="continue pending"} 0
 windows_service_state{name="qwave",state="pause pending"} 0
 windows_service_state{name="qwave",state="paused"} 0
@@ -2094,6 +2752,14 @@ windows_service_state{name="remoteregistry",state="start pending"} 0
 windows_service_state{name="remoteregistry",state="stop pending"} 0
 windows_service_state{name="remoteregistry",state="stopped"} 1
 windows_service_state{name="remoteregistry",state="unknown"} 0
+windows_service_state{name="retaildemo",state="continue pending"} 0
+windows_service_state{name="retaildemo",state="pause pending"} 0
+windows_service_state{name="retaildemo",state="paused"} 0
+windows_service_state{name="retaildemo",state="running"} 0
+windows_service_state{name="retaildemo",state="start pending"} 0
+windows_service_state{name="retaildemo",state="stop pending"} 0
+windows_service_state{name="retaildemo",state="stopped"} 1
+windows_service_state{name="retaildemo",state="unknown"} 0
 windows_service_state{name="rmsvc",state="continue pending"} 0
 windows_service_state{name="rmsvc",state="pause pending"} 0
 windows_service_state{name="rmsvc",state="paused"} 0
@@ -2126,22 +2792,6 @@ windows_service_state{name="rpcss",state="start pending"} 0
 windows_service_state{name="rpcss",state="stop pending"} 0
 windows_service_state{name="rpcss",state="stopped"} 0
 windows_service_state{name="rpcss",state="unknown"} 0
-windows_service_state{name="rsopprov",state="continue pending"} 0
-windows_service_state{name="rsopprov",state="pause pending"} 0
-windows_service_state{name="rsopprov",state="paused"} 0
-windows_service_state{name="rsopprov",state="running"} 0
-windows_service_state{name="rsopprov",state="start pending"} 0
-windows_service_state{name="rsopprov",state="stop pending"} 0
-windows_service_state{name="rsopprov",state="stopped"} 1
-windows_service_state{name="rsopprov",state="unknown"} 0
-windows_service_state{name="sacsvr",state="continue pending"} 0
-windows_service_state{name="sacsvr",state="pause pending"} 0
-windows_service_state{name="sacsvr",state="paused"} 0
-windows_service_state{name="sacsvr",state="running"} 0
-windows_service_state{name="sacsvr",state="start pending"} 0
-windows_service_state{name="sacsvr",state="stop pending"} 0
-windows_service_state{name="sacsvr",state="stopped"} 1
-windows_service_state{name="sacsvr",state="unknown"} 0
 windows_service_state{name="samss",state="continue pending"} 0
 windows_service_state{name="samss",state="pause pending"} 0
 windows_service_state{name="samss",state="paused"} 0
@@ -2182,6 +2832,14 @@ windows_service_state{name="scpolicysvc",state="start pending"} 0
 windows_service_state{name="scpolicysvc",state="stop pending"} 0
 windows_service_state{name="scpolicysvc",state="stopped"} 1
 windows_service_state{name="scpolicysvc",state="unknown"} 0
+windows_service_state{name="sdrsvc",state="continue pending"} 0
+windows_service_state{name="sdrsvc",state="pause pending"} 0
+windows_service_state{name="sdrsvc",state="paused"} 0
+windows_service_state{name="sdrsvc",state="running"} 0
+windows_service_state{name="sdrsvc",state="start pending"} 0
+windows_service_state{name="sdrsvc",state="stop pending"} 0
+windows_service_state{name="sdrsvc",state="stopped"} 1
+windows_service_state{name="sdrsvc",state="unknown"} 0
 windows_service_state{name="seclogon",state="continue pending"} 0
 windows_service_state{name="seclogon",state="pause pending"} 0
 windows_service_state{name="seclogon",state="paused"} 0
@@ -2190,6 +2848,22 @@ windows_service_state{name="seclogon",state="start pending"} 0
 windows_service_state{name="seclogon",state="stop pending"} 0
 windows_service_state{name="seclogon",state="stopped"} 1
 windows_service_state{name="seclogon",state="unknown"} 0
+windows_service_state{name="securityhealthservice",state="continue pending"} 0
+windows_service_state{name="securityhealthservice",state="pause pending"} 0
+windows_service_state{name="securityhealthservice",state="paused"} 0
+windows_service_state{name="securityhealthservice",state="running"} 1
+windows_service_state{name="securityhealthservice",state="start pending"} 0
+windows_service_state{name="securityhealthservice",state="stop pending"} 0
+windows_service_state{name="securityhealthservice",state="stopped"} 0
+windows_service_state{name="securityhealthservice",state="unknown"} 0
+windows_service_state{name="semgrsvc",state="continue pending"} 0
+windows_service_state{name="semgrsvc",state="pause pending"} 0
+windows_service_state{name="semgrsvc",state="paused"} 0
+windows_service_state{name="semgrsvc",state="running"} 1
+windows_service_state{name="semgrsvc",state="start pending"} 0
+windows_service_state{name="semgrsvc",state="stop pending"} 0
+windows_service_state{name="semgrsvc",state="stopped"} 0
+windows_service_state{name="semgrsvc",state="unknown"} 0
 windows_service_state{name="sens",state="continue pending"} 0
 windows_service_state{name="sens",state="pause pending"} 0
 windows_service_state{name="sens",state="paused"} 0
@@ -2198,6 +2872,14 @@ windows_service_state{name="sens",state="start pending"} 0
 windows_service_state{name="sens",state="stop pending"} 0
 windows_service_state{name="sens",state="stopped"} 0
 windows_service_state{name="sens",state="unknown"} 0
+windows_service_state{name="sense",state="continue pending"} 0
+windows_service_state{name="sense",state="pause pending"} 0
+windows_service_state{name="sense",state="paused"} 0
+windows_service_state{name="sense",state="running"} 0
+windows_service_state{name="sense",state="start pending"} 0
+windows_service_state{name="sense",state="stop pending"} 0
+windows_service_state{name="sense",state="stopped"} 1
+windows_service_state{name="sense",state="unknown"} 0
 windows_service_state{name="sensordataservice",state="continue pending"} 0
 windows_service_state{name="sensordataservice",state="pause pending"} 0
 windows_service_state{name="sensordataservice",state="paused"} 0
@@ -2230,6 +2912,14 @@ windows_service_state{name="sessionenv",state="start pending"} 0
 windows_service_state{name="sessionenv",state="stop pending"} 0
 windows_service_state{name="sessionenv",state="stopped"} 1
 windows_service_state{name="sessionenv",state="unknown"} 0
+windows_service_state{name="sgrmbroker",state="continue pending"} 0
+windows_service_state{name="sgrmbroker",state="pause pending"} 0
+windows_service_state{name="sgrmbroker",state="paused"} 0
+windows_service_state{name="sgrmbroker",state="running"} 1
+windows_service_state{name="sgrmbroker",state="start pending"} 0
+windows_service_state{name="sgrmbroker",state="stop pending"} 0
+windows_service_state{name="sgrmbroker",state="stopped"} 0
+windows_service_state{name="sgrmbroker",state="unknown"} 0
 windows_service_state{name="sharedaccess",state="continue pending"} 0
 windows_service_state{name="sharedaccess",state="pause pending"} 0
 windows_service_state{name="sharedaccess",state="paused"} 0
@@ -2238,6 +2928,14 @@ windows_service_state{name="sharedaccess",state="start pending"} 0
 windows_service_state{name="sharedaccess",state="stop pending"} 0
 windows_service_state{name="sharedaccess",state="stopped"} 1
 windows_service_state{name="sharedaccess",state="unknown"} 0
+windows_service_state{name="sharedrealitysvc",state="continue pending"} 0
+windows_service_state{name="sharedrealitysvc",state="pause pending"} 0
+windows_service_state{name="sharedrealitysvc",state="paused"} 0
+windows_service_state{name="sharedrealitysvc",state="running"} 0
+windows_service_state{name="sharedrealitysvc",state="start pending"} 0
+windows_service_state{name="sharedrealitysvc",state="stop pending"} 0
+windows_service_state{name="sharedrealitysvc",state="stopped"} 1
+windows_service_state{name="sharedrealitysvc",state="unknown"} 0
 windows_service_state{name="shellhwdetection",state="continue pending"} 0
 windows_service_state{name="shellhwdetection",state="pause pending"} 0
 windows_service_state{name="shellhwdetection",state="paused"} 0
@@ -2246,6 +2944,14 @@ windows_service_state{name="shellhwdetection",state="start pending"} 0
 windows_service_state{name="shellhwdetection",state="stop pending"} 0
 windows_service_state{name="shellhwdetection",state="stopped"} 0
 windows_service_state{name="shellhwdetection",state="unknown"} 0
+windows_service_state{name="shpamsvc",state="continue pending"} 0
+windows_service_state{name="shpamsvc",state="pause pending"} 0
+windows_service_state{name="shpamsvc",state="paused"} 0
+windows_service_state{name="shpamsvc",state="running"} 0
+windows_service_state{name="shpamsvc",state="start pending"} 0
+windows_service_state{name="shpamsvc",state="stop pending"} 0
+windows_service_state{name="shpamsvc",state="stopped"} 1
+windows_service_state{name="shpamsvc",state="unknown"} 0
 windows_service_state{name="smphost",state="continue pending"} 0
 windows_service_state{name="smphost",state="pause pending"} 0
 windows_service_state{name="smphost",state="paused"} 0
@@ -2254,6 +2960,14 @@ windows_service_state{name="smphost",state="start pending"} 0
 windows_service_state{name="smphost",state="stop pending"} 0
 windows_service_state{name="smphost",state="stopped"} 1
 windows_service_state{name="smphost",state="unknown"} 0
+windows_service_state{name="smsrouter",state="continue pending"} 0
+windows_service_state{name="smsrouter",state="pause pending"} 0
+windows_service_state{name="smsrouter",state="paused"} 0
+windows_service_state{name="smsrouter",state="running"} 0
+windows_service_state{name="smsrouter",state="start pending"} 0
+windows_service_state{name="smsrouter",state="stop pending"} 0
+windows_service_state{name="smsrouter",state="stopped"} 1
+windows_service_state{name="smsrouter",state="unknown"} 0
 windows_service_state{name="snmptrap",state="continue pending"} 0
 windows_service_state{name="snmptrap",state="pause pending"} 0
 windows_service_state{name="snmptrap",state="paused"} 0
@@ -2262,6 +2976,14 @@ windows_service_state{name="snmptrap",state="start pending"} 0
 windows_service_state{name="snmptrap",state="stop pending"} 0
 windows_service_state{name="snmptrap",state="stopped"} 1
 windows_service_state{name="snmptrap",state="unknown"} 0
+windows_service_state{name="spectrum",state="continue pending"} 0
+windows_service_state{name="spectrum",state="pause pending"} 0
+windows_service_state{name="spectrum",state="paused"} 0
+windows_service_state{name="spectrum",state="running"} 0
+windows_service_state{name="spectrum",state="start pending"} 0
+windows_service_state{name="spectrum",state="stop pending"} 0
+windows_service_state{name="spectrum",state="stopped"} 1
+windows_service_state{name="spectrum",state="unknown"} 0
 windows_service_state{name="spooler",state="continue pending"} 0
 windows_service_state{name="spooler",state="pause pending"} 0
 windows_service_state{name="spooler",state="paused"} 0
@@ -2286,6 +3008,14 @@ windows_service_state{name="ssdpsrv",state="start pending"} 0
 windows_service_state{name="ssdpsrv",state="stop pending"} 0
 windows_service_state{name="ssdpsrv",state="stopped"} 0
 windows_service_state{name="ssdpsrv",state="unknown"} 0
+windows_service_state{name="ssh-agent",state="continue pending"} 0
+windows_service_state{name="ssh-agent",state="pause pending"} 0
+windows_service_state{name="ssh-agent",state="paused"} 0
+windows_service_state{name="ssh-agent",state="running"} 0
+windows_service_state{name="ssh-agent",state="start pending"} 0
+windows_service_state{name="ssh-agent",state="stop pending"} 0
+windows_service_state{name="ssh-agent",state="stopped"} 1
+windows_service_state{name="ssh-agent",state="unknown"} 0
 windows_service_state{name="sstpsvc",state="continue pending"} 0
 windows_service_state{name="sstpsvc",state="pause pending"} 0
 windows_service_state{name="sstpsvc",state="paused"} 0
@@ -2337,10 +3067,10 @@ windows_service_state{name="swprv",state="unknown"} 0
 windows_service_state{name="sysmain",state="continue pending"} 0
 windows_service_state{name="sysmain",state="pause pending"} 0
 windows_service_state{name="sysmain",state="paused"} 0
-windows_service_state{name="sysmain",state="running"} 0
+windows_service_state{name="sysmain",state="running"} 1
 windows_service_state{name="sysmain",state="start pending"} 0
 windows_service_state{name="sysmain",state="stop pending"} 0
-windows_service_state{name="sysmain",state="stopped"} 1
+windows_service_state{name="sysmain",state="stopped"} 0
 windows_service_state{name="sysmain",state="unknown"} 0
 windows_service_state{name="systemeventsbroker",state="continue pending"} 0
 windows_service_state{name="systemeventsbroker",state="pause pending"} 0
@@ -2353,10 +3083,10 @@ windows_service_state{name="systemeventsbroker",state="unknown"} 0
 windows_service_state{name="tabletinputservice",state="continue pending"} 0
 windows_service_state{name="tabletinputservice",state="pause pending"} 0
 windows_service_state{name="tabletinputservice",state="paused"} 0
-windows_service_state{name="tabletinputservice",state="running"} 0
+windows_service_state{name="tabletinputservice",state="running"} 1
 windows_service_state{name="tabletinputservice",state="start pending"} 0
 windows_service_state{name="tabletinputservice",state="stop pending"} 0
-windows_service_state{name="tabletinputservice",state="stopped"} 1
+windows_service_state{name="tabletinputservice",state="stopped"} 0
 windows_service_state{name="tabletinputservice",state="unknown"} 0
 windows_service_state{name="tapisrv",state="continue pending"} 0
 windows_service_state{name="tapisrv",state="pause pending"} 0
@@ -2366,6 +3096,14 @@ windows_service_state{name="tapisrv",state="start pending"} 0
 windows_service_state{name="tapisrv",state="stop pending"} 0
 windows_service_state{name="tapisrv",state="stopped"} 1
 windows_service_state{name="tapisrv",state="unknown"} 0
+windows_service_state{name="te.service",state="continue pending"} 0
+windows_service_state{name="te.service",state="pause pending"} 0
+windows_service_state{name="te.service",state="paused"} 0
+windows_service_state{name="te.service",state="running"} 0
+windows_service_state{name="te.service",state="start pending"} 0
+windows_service_state{name="te.service",state="stop pending"} 0
+windows_service_state{name="te.service",state="stopped"} 1
+windows_service_state{name="te.service",state="unknown"} 0
 windows_service_state{name="termservice",state="continue pending"} 0
 windows_service_state{name="termservice",state="pause pending"} 0
 windows_service_state{name="termservice",state="paused"} 0
@@ -2390,14 +3128,6 @@ windows_service_state{name="tieringengineservice",state="start pending"} 0
 windows_service_state{name="tieringengineservice",state="stop pending"} 0
 windows_service_state{name="tieringengineservice",state="stopped"} 1
 windows_service_state{name="tieringengineservice",state="unknown"} 0
-windows_service_state{name="tiledatamodelsvc",state="continue pending"} 0
-windows_service_state{name="tiledatamodelsvc",state="pause pending"} 0
-windows_service_state{name="tiledatamodelsvc",state="paused"} 0
-windows_service_state{name="tiledatamodelsvc",state="running"} 1
-windows_service_state{name="tiledatamodelsvc",state="start pending"} 0
-windows_service_state{name="tiledatamodelsvc",state="stop pending"} 0
-windows_service_state{name="tiledatamodelsvc",state="stopped"} 0
-windows_service_state{name="tiledatamodelsvc",state="unknown"} 0
 windows_service_state{name="timebrokersvc",state="continue pending"} 0
 windows_service_state{name="timebrokersvc",state="pause pending"} 0
 windows_service_state{name="timebrokersvc",state="paused"} 0
@@ -2406,6 +3136,14 @@ windows_service_state{name="timebrokersvc",state="start pending"} 0
 windows_service_state{name="timebrokersvc",state="stop pending"} 0
 windows_service_state{name="timebrokersvc",state="stopped"} 0
 windows_service_state{name="timebrokersvc",state="unknown"} 0
+windows_service_state{name="tokenbroker",state="continue pending"} 0
+windows_service_state{name="tokenbroker",state="pause pending"} 0
+windows_service_state{name="tokenbroker",state="paused"} 0
+windows_service_state{name="tokenbroker",state="running"} 1
+windows_service_state{name="tokenbroker",state="start pending"} 0
+windows_service_state{name="tokenbroker",state="stop pending"} 0
+windows_service_state{name="tokenbroker",state="stopped"} 0
+windows_service_state{name="tokenbroker",state="unknown"} 0
 windows_service_state{name="trkwks",state="continue pending"} 0
 windows_service_state{name="trkwks",state="pause pending"} 0
 windows_service_state{name="trkwks",state="paused"} 0
@@ -2414,6 +3152,14 @@ windows_service_state{name="trkwks",state="start pending"} 0
 windows_service_state{name="trkwks",state="stop pending"} 0
 windows_service_state{name="trkwks",state="stopped"} 0
 windows_service_state{name="trkwks",state="unknown"} 0
+windows_service_state{name="troubleshootingsvc",state="continue pending"} 0
+windows_service_state{name="troubleshootingsvc",state="pause pending"} 0
+windows_service_state{name="troubleshootingsvc",state="paused"} 0
+windows_service_state{name="troubleshootingsvc",state="running"} 0
+windows_service_state{name="troubleshootingsvc",state="start pending"} 0
+windows_service_state{name="troubleshootingsvc",state="stop pending"} 0
+windows_service_state{name="troubleshootingsvc",state="stopped"} 1
+windows_service_state{name="troubleshootingsvc",state="unknown"} 0
 windows_service_state{name="trustedinstaller",state="continue pending"} 0
 windows_service_state{name="trustedinstaller",state="pause pending"} 0
 windows_service_state{name="trustedinstaller",state="paused"} 0
@@ -2430,14 +3176,6 @@ windows_service_state{name="tzautoupdate",state="start pending"} 0
 windows_service_state{name="tzautoupdate",state="stop pending"} 0
 windows_service_state{name="tzautoupdate",state="stopped"} 1
 windows_service_state{name="tzautoupdate",state="unknown"} 0
-windows_service_state{name="ualsvc",state="continue pending"} 0
-windows_service_state{name="ualsvc",state="pause pending"} 0
-windows_service_state{name="ualsvc",state="paused"} 0
-windows_service_state{name="ualsvc",state="running"} 1
-windows_service_state{name="ualsvc",state="start pending"} 0
-windows_service_state{name="ualsvc",state="stop pending"} 0
-windows_service_state{name="ualsvc",state="stopped"} 0
-windows_service_state{name="ualsvc",state="unknown"} 0
 windows_service_state{name="uevagentservice",state="continue pending"} 0
 windows_service_state{name="uevagentservice",state="pause pending"} 0
 windows_service_state{name="uevagentservice",state="paused"} 0
@@ -2446,14 +3184,6 @@ windows_service_state{name="uevagentservice",state="start pending"} 0
 windows_service_state{name="uevagentservice",state="stop pending"} 0
 windows_service_state{name="uevagentservice",state="stopped"} 1
 windows_service_state{name="uevagentservice",state="unknown"} 0
-windows_service_state{name="ui0detect",state="continue pending"} 0
-windows_service_state{name="ui0detect",state="pause pending"} 0
-windows_service_state{name="ui0detect",state="paused"} 0
-windows_service_state{name="ui0detect",state="running"} 0
-windows_service_state{name="ui0detect",state="start pending"} 0
-windows_service_state{name="ui0detect",state="stop pending"} 0
-windows_service_state{name="ui0detect",state="stopped"} 1
-windows_service_state{name="ui0detect",state="unknown"} 0
 windows_service_state{name="umrdpservice",state="continue pending"} 0
 windows_service_state{name="umrdpservice",state="pause pending"} 0
 windows_service_state{name="umrdpservice",state="paused"} 0
@@ -2462,14 +3192,14 @@ windows_service_state{name="umrdpservice",state="start pending"} 0
 windows_service_state{name="umrdpservice",state="stop pending"} 0
 windows_service_state{name="umrdpservice",state="stopped"} 1
 windows_service_state{name="umrdpservice",state="unknown"} 0
-windows_service_state{name="unistoresvc_225e3",state="continue pending"} 0
-windows_service_state{name="unistoresvc_225e3",state="pause pending"} 0
-windows_service_state{name="unistoresvc_225e3",state="paused"} 0
-windows_service_state{name="unistoresvc_225e3",state="running"} 0
-windows_service_state{name="unistoresvc_225e3",state="start pending"} 0
-windows_service_state{name="unistoresvc_225e3",state="stop pending"} 0
-windows_service_state{name="unistoresvc_225e3",state="stopped"} 1
-windows_service_state{name="unistoresvc_225e3",state="unknown"} 0
+windows_service_state{name="unistoresvc_390e7",state="continue pending"} 0
+windows_service_state{name="unistoresvc_390e7",state="pause pending"} 0
+windows_service_state{name="unistoresvc_390e7",state="paused"} 0
+windows_service_state{name="unistoresvc_390e7",state="running"} 0
+windows_service_state{name="unistoresvc_390e7",state="start pending"} 0
+windows_service_state{name="unistoresvc_390e7",state="stop pending"} 0
+windows_service_state{name="unistoresvc_390e7",state="stopped"} 1
+windows_service_state{name="unistoresvc_390e7",state="unknown"} 0
 windows_service_state{name="upnphost",state="continue pending"} 0
 windows_service_state{name="upnphost",state="pause pending"} 0
 windows_service_state{name="upnphost",state="paused"} 0
@@ -2478,14 +3208,14 @@ windows_service_state{name="upnphost",state="start pending"} 0
 windows_service_state{name="upnphost",state="stop pending"} 0
 windows_service_state{name="upnphost",state="stopped"} 1
 windows_service_state{name="upnphost",state="unknown"} 0
-windows_service_state{name="userdatasvc_225e3",state="continue pending"} 0
-windows_service_state{name="userdatasvc_225e3",state="pause pending"} 0
-windows_service_state{name="userdatasvc_225e3",state="paused"} 0
-windows_service_state{name="userdatasvc_225e3",state="running"} 0
-windows_service_state{name="userdatasvc_225e3",state="start pending"} 0
-windows_service_state{name="userdatasvc_225e3",state="stop pending"} 0
-windows_service_state{name="userdatasvc_225e3",state="stopped"} 1
-windows_service_state{name="userdatasvc_225e3",state="unknown"} 0
+windows_service_state{name="userdatasvc_390e7",state="continue pending"} 0
+windows_service_state{name="userdatasvc_390e7",state="pause pending"} 0
+windows_service_state{name="userdatasvc_390e7",state="paused"} 0
+windows_service_state{name="userdatasvc_390e7",state="running"} 0
+windows_service_state{name="userdatasvc_390e7",state="start pending"} 0
+windows_service_state{name="userdatasvc_390e7",state="stop pending"} 0
+windows_service_state{name="userdatasvc_390e7",state="stopped"} 1
+windows_service_state{name="userdatasvc_390e7",state="unknown"} 0
 windows_service_state{name="usermanager",state="continue pending"} 0
 windows_service_state{name="usermanager",state="pause pending"} 0
 windows_service_state{name="usermanager",state="paused"} 0
@@ -2497,11 +3227,19 @@ windows_service_state{name="usermanager",state="unknown"} 0
 windows_service_state{name="usosvc",state="continue pending"} 0
 windows_service_state{name="usosvc",state="pause pending"} 0
 windows_service_state{name="usosvc",state="paused"} 0
-windows_service_state{name="usosvc",state="running"} 0
+windows_service_state{name="usosvc",state="running"} 1
 windows_service_state{name="usosvc",state="start pending"} 0
 windows_service_state{name="usosvc",state="stop pending"} 0
-windows_service_state{name="usosvc",state="stopped"} 1
+windows_service_state{name="usosvc",state="stopped"} 0
 windows_service_state{name="usosvc",state="unknown"} 0
+windows_service_state{name="vacsvc",state="continue pending"} 0
+windows_service_state{name="vacsvc",state="pause pending"} 0
+windows_service_state{name="vacsvc",state="paused"} 0
+windows_service_state{name="vacsvc",state="running"} 0
+windows_service_state{name="vacsvc",state="start pending"} 0
+windows_service_state{name="vacsvc",state="stop pending"} 0
+windows_service_state{name="vacsvc",state="stopped"} 1
+windows_service_state{name="vacsvc",state="unknown"} 0
 windows_service_state{name="vaultsvc",state="continue pending"} 0
 windows_service_state{name="vaultsvc",state="pause pending"} 0
 windows_service_state{name="vaultsvc",state="paused"} 0
@@ -2601,27 +3339,19 @@ windows_service_state{name="vss",state="unknown"} 0
 windows_service_state{name="w32time",state="continue pending"} 0
 windows_service_state{name="w32time",state="pause pending"} 0
 windows_service_state{name="w32time",state="paused"} 0
-windows_service_state{name="w32time",state="running"} 1
+windows_service_state{name="w32time",state="running"} 0
 windows_service_state{name="w32time",state="start pending"} 0
 windows_service_state{name="w32time",state="stop pending"} 0
-windows_service_state{name="w32time",state="stopped"} 0
+windows_service_state{name="w32time",state="stopped"} 1
 windows_service_state{name="w32time",state="unknown"} 0
-windows_service_state{name="w3logsvc",state="continue pending"} 0
-windows_service_state{name="w3logsvc",state="pause pending"} 0
-windows_service_state{name="w3logsvc",state="paused"} 0
-windows_service_state{name="w3logsvc",state="running"} 0
-windows_service_state{name="w3logsvc",state="start pending"} 0
-windows_service_state{name="w3logsvc",state="stop pending"} 0
-windows_service_state{name="w3logsvc",state="stopped"} 1
-windows_service_state{name="w3logsvc",state="unknown"} 0
-windows_service_state{name="w3svc",state="continue pending"} 0
-windows_service_state{name="w3svc",state="pause pending"} 0
-windows_service_state{name="w3svc",state="paused"} 0
-windows_service_state{name="w3svc",state="running"} 1
-windows_service_state{name="w3svc",state="start pending"} 0
-windows_service_state{name="w3svc",state="stop pending"} 0
-windows_service_state{name="w3svc",state="stopped"} 0
-windows_service_state{name="w3svc",state="unknown"} 0
+windows_service_state{name="waasmedicsvc",state="continue pending"} 0
+windows_service_state{name="waasmedicsvc",state="pause pending"} 0
+windows_service_state{name="waasmedicsvc",state="paused"} 0
+windows_service_state{name="waasmedicsvc",state="running"} 0
+windows_service_state{name="waasmedicsvc",state="start pending"} 0
+windows_service_state{name="waasmedicsvc",state="stop pending"} 0
+windows_service_state{name="waasmedicsvc",state="stopped"} 1
+windows_service_state{name="waasmedicsvc",state="unknown"} 0
 windows_service_state{name="walletservice",state="continue pending"} 0
 windows_service_state{name="walletservice",state="pause pending"} 0
 windows_service_state{name="walletservice",state="paused"} 0
@@ -2630,14 +3360,22 @@ windows_service_state{name="walletservice",state="start pending"} 0
 windows_service_state{name="walletservice",state="stop pending"} 0
 windows_service_state{name="walletservice",state="stopped"} 1
 windows_service_state{name="walletservice",state="unknown"} 0
-windows_service_state{name="was",state="continue pending"} 0
-windows_service_state{name="was",state="pause pending"} 0
-windows_service_state{name="was",state="paused"} 0
-windows_service_state{name="was",state="running"} 1
-windows_service_state{name="was",state="start pending"} 0
-windows_service_state{name="was",state="stop pending"} 0
-windows_service_state{name="was",state="stopped"} 0
-windows_service_state{name="was",state="unknown"} 0
+windows_service_state{name="warpjitsvc",state="continue pending"} 0
+windows_service_state{name="warpjitsvc",state="pause pending"} 0
+windows_service_state{name="warpjitsvc",state="paused"} 0
+windows_service_state{name="warpjitsvc",state="running"} 0
+windows_service_state{name="warpjitsvc",state="start pending"} 0
+windows_service_state{name="warpjitsvc",state="stop pending"} 0
+windows_service_state{name="warpjitsvc",state="stopped"} 1
+windows_service_state{name="warpjitsvc",state="unknown"} 0
+windows_service_state{name="wbengine",state="continue pending"} 0
+windows_service_state{name="wbengine",state="pause pending"} 0
+windows_service_state{name="wbengine",state="paused"} 0
+windows_service_state{name="wbengine",state="running"} 0
+windows_service_state{name="wbengine",state="start pending"} 0
+windows_service_state{name="wbengine",state="stop pending"} 0
+windows_service_state{name="wbengine",state="stopped"} 1
+windows_service_state{name="wbengine",state="unknown"} 0
 windows_service_state{name="wbiosrvc",state="continue pending"} 0
 windows_service_state{name="wbiosrvc",state="pause pending"} 0
 windows_service_state{name="wbiosrvc",state="paused"} 0
@@ -2654,13 +3392,21 @@ windows_service_state{name="wcmsvc",state="start pending"} 0
 windows_service_state{name="wcmsvc",state="stop pending"} 0
 windows_service_state{name="wcmsvc",state="stopped"} 0
 windows_service_state{name="wcmsvc",state="unknown"} 0
+windows_service_state{name="wcncsvc",state="continue pending"} 0
+windows_service_state{name="wcncsvc",state="pause pending"} 0
+windows_service_state{name="wcncsvc",state="paused"} 0
+windows_service_state{name="wcncsvc",state="running"} 0
+windows_service_state{name="wcncsvc",state="start pending"} 0
+windows_service_state{name="wcncsvc",state="stop pending"} 0
+windows_service_state{name="wcncsvc",state="stopped"} 1
+windows_service_state{name="wcncsvc",state="unknown"} 0
 windows_service_state{name="wdiservicehost",state="continue pending"} 0
 windows_service_state{name="wdiservicehost",state="pause pending"} 0
 windows_service_state{name="wdiservicehost",state="paused"} 0
-windows_service_state{name="wdiservicehost",state="running"} 0
+windows_service_state{name="wdiservicehost",state="running"} 1
 windows_service_state{name="wdiservicehost",state="start pending"} 0
 windows_service_state{name="wdiservicehost",state="stop pending"} 0
-windows_service_state{name="wdiservicehost",state="stopped"} 1
+windows_service_state{name="wdiservicehost",state="stopped"} 0
 windows_service_state{name="wdiservicehost",state="unknown"} 0
 windows_service_state{name="wdisystemhost",state="continue pending"} 0
 windows_service_state{name="wdisystemhost",state="pause pending"} 0
@@ -2673,11 +3419,19 @@ windows_service_state{name="wdisystemhost",state="unknown"} 0
 windows_service_state{name="wdnissvc",state="continue pending"} 0
 windows_service_state{name="wdnissvc",state="pause pending"} 0
 windows_service_state{name="wdnissvc",state="paused"} 0
-windows_service_state{name="wdnissvc",state="running"} 0
+windows_service_state{name="wdnissvc",state="running"} 1
 windows_service_state{name="wdnissvc",state="start pending"} 0
 windows_service_state{name="wdnissvc",state="stop pending"} 0
-windows_service_state{name="wdnissvc",state="stopped"} 1
+windows_service_state{name="wdnissvc",state="stopped"} 0
 windows_service_state{name="wdnissvc",state="unknown"} 0
+windows_service_state{name="webclient",state="continue pending"} 0
+windows_service_state{name="webclient",state="pause pending"} 0
+windows_service_state{name="webclient",state="paused"} 0
+windows_service_state{name="webclient",state="running"} 0
+windows_service_state{name="webclient",state="start pending"} 0
+windows_service_state{name="webclient",state="stop pending"} 0
+windows_service_state{name="webclient",state="stopped"} 1
+windows_service_state{name="webclient",state="unknown"} 0
 windows_service_state{name="wecsvc",state="continue pending"} 0
 windows_service_state{name="wecsvc",state="pause pending"} 0
 windows_service_state{name="wecsvc",state="paused"} 0
@@ -2710,6 +3464,14 @@ windows_service_state{name="wersvc",state="start pending"} 0
 windows_service_state{name="wersvc",state="stop pending"} 0
 windows_service_state{name="wersvc",state="stopped"} 1
 windows_service_state{name="wersvc",state="unknown"} 0
+windows_service_state{name="wfdsconmgrsvc",state="continue pending"} 0
+windows_service_state{name="wfdsconmgrsvc",state="pause pending"} 0
+windows_service_state{name="wfdsconmgrsvc",state="paused"} 0
+windows_service_state{name="wfdsconmgrsvc",state="running"} 0
+windows_service_state{name="wfdsconmgrsvc",state="start pending"} 0
+windows_service_state{name="wfdsconmgrsvc",state="stop pending"} 0
+windows_service_state{name="wfdsconmgrsvc",state="stopped"} 1
+windows_service_state{name="wfdsconmgrsvc",state="unknown"} 0
 windows_service_state{name="wiarpc",state="continue pending"} 0
 windows_service_state{name="wiarpc",state="pause pending"} 0
 windows_service_state{name="wiarpc",state="paused"} 0
@@ -2745,10 +3507,10 @@ windows_service_state{name="winmgmt",state="unknown"} 0
 windows_service_state{name="winrm",state="continue pending"} 0
 windows_service_state{name="winrm",state="pause pending"} 0
 windows_service_state{name="winrm",state="paused"} 0
-windows_service_state{name="winrm",state="running"} 1
+windows_service_state{name="winrm",state="running"} 0
 windows_service_state{name="winrm",state="start pending"} 0
 windows_service_state{name="winrm",state="stop pending"} 0
-windows_service_state{name="winrm",state="stopped"} 0
+windows_service_state{name="winrm",state="stopped"} 1
 windows_service_state{name="winrm",state="unknown"} 0
 windows_service_state{name="wisvc",state="continue pending"} 0
 windows_service_state{name="wisvc",state="pause pending"} 0
@@ -2758,6 +3520,14 @@ windows_service_state{name="wisvc",state="start pending"} 0
 windows_service_state{name="wisvc",state="stop pending"} 0
 windows_service_state{name="wisvc",state="stopped"} 1
 windows_service_state{name="wisvc",state="unknown"} 0
+windows_service_state{name="wlansvc",state="continue pending"} 0
+windows_service_state{name="wlansvc",state="pause pending"} 0
+windows_service_state{name="wlansvc",state="paused"} 0
+windows_service_state{name="wlansvc",state="running"} 0
+windows_service_state{name="wlansvc",state="start pending"} 0
+windows_service_state{name="wlansvc",state="stop pending"} 0
+windows_service_state{name="wlansvc",state="stopped"} 1
+windows_service_state{name="wlansvc",state="unknown"} 0
 windows_service_state{name="wlidsvc",state="continue pending"} 0
 windows_service_state{name="wlidsvc",state="pause pending"} 0
 windows_service_state{name="wlidsvc",state="paused"} 0
@@ -2774,22 +3544,54 @@ windows_service_state{name="wlms",state="start pending"} 0
 windows_service_state{name="wlms",state="stop pending"} 0
 windows_service_state{name="wlms",state="stopped"} 0
 windows_service_state{name="wlms",state="unknown"} 0
-windows_service_state{name="windows_exporter",state="continue pending"} 0
-windows_service_state{name="windows_exporter",state="pause pending"} 0
-windows_service_state{name="windows_exporter",state="paused"} 0
-windows_service_state{name="windows_exporter",state="running"} 0
-windows_service_state{name="windows_exporter",state="start pending"} 0
-windows_service_state{name="windows_exporter",state="stop pending"} 0
-windows_service_state{name="windows_exporter",state="stopped"} 1
-windows_service_state{name="windows_exporter",state="unknown"} 0
+windows_service_state{name="wlpasvc",state="continue pending"} 0
+windows_service_state{name="wlpasvc",state="pause pending"} 0
+windows_service_state{name="wlpasvc",state="paused"} 0
+windows_service_state{name="wlpasvc",state="running"} 0
+windows_service_state{name="wlpasvc",state="start pending"} 0
+windows_service_state{name="wlpasvc",state="stop pending"} 0
+windows_service_state{name="wlpasvc",state="stopped"} 1
+windows_service_state{name="wlpasvc",state="unknown"} 0
+windows_service_state{name="wmansvc",state="continue pending"} 0
+windows_service_state{name="wmansvc",state="pause pending"} 0
+windows_service_state{name="wmansvc",state="paused"} 0
+windows_service_state{name="wmansvc",state="running"} 0
+windows_service_state{name="wmansvc",state="start pending"} 0
+windows_service_state{name="wmansvc",state="stop pending"} 0
+windows_service_state{name="wmansvc",state="stopped"} 1
+windows_service_state{name="wmansvc",state="unknown"} 0
 windows_service_state{name="wmiapsrv",state="continue pending"} 0
 windows_service_state{name="wmiapsrv",state="pause pending"} 0
 windows_service_state{name="wmiapsrv",state="paused"} 0
-windows_service_state{name="wmiapsrv",state="running"} 1
+windows_service_state{name="wmiapsrv",state="running"} 0
 windows_service_state{name="wmiapsrv",state="start pending"} 0
 windows_service_state{name="wmiapsrv",state="stop pending"} 0
-windows_service_state{name="wmiapsrv",state="stopped"} 0
+windows_service_state{name="wmiapsrv",state="stopped"} 1
 windows_service_state{name="wmiapsrv",state="unknown"} 0
+windows_service_state{name="wmpnetworksvc",state="continue pending"} 0
+windows_service_state{name="wmpnetworksvc",state="pause pending"} 0
+windows_service_state{name="wmpnetworksvc",state="paused"} 0
+windows_service_state{name="wmpnetworksvc",state="running"} 0
+windows_service_state{name="wmpnetworksvc",state="start pending"} 0
+windows_service_state{name="wmpnetworksvc",state="stop pending"} 0
+windows_service_state{name="wmpnetworksvc",state="stopped"} 1
+windows_service_state{name="wmpnetworksvc",state="unknown"} 0
+windows_service_state{name="workfolderssvc",state="continue pending"} 0
+windows_service_state{name="workfolderssvc",state="pause pending"} 0
+windows_service_state{name="workfolderssvc",state="paused"} 0
+windows_service_state{name="workfolderssvc",state="running"} 0
+windows_service_state{name="workfolderssvc",state="start pending"} 0
+windows_service_state{name="workfolderssvc",state="stop pending"} 0
+windows_service_state{name="workfolderssvc",state="stopped"} 1
+windows_service_state{name="workfolderssvc",state="unknown"} 0
+windows_service_state{name="wpcmonsvc",state="continue pending"} 0
+windows_service_state{name="wpcmonsvc",state="pause pending"} 0
+windows_service_state{name="wpcmonsvc",state="paused"} 0
+windows_service_state{name="wpcmonsvc",state="running"} 0
+windows_service_state{name="wpcmonsvc",state="start pending"} 0
+windows_service_state{name="wpcmonsvc",state="stop pending"} 0
+windows_service_state{name="wpcmonsvc",state="stopped"} 1
+windows_service_state{name="wpcmonsvc",state="unknown"} 0
 windows_service_state{name="wpdbusenum",state="continue pending"} 0
 windows_service_state{name="wpdbusenum",state="pause pending"} 0
 windows_service_state{name="wpdbusenum",state="paused"} 0
@@ -2806,38 +3608,46 @@ windows_service_state{name="wpnservice",state="start pending"} 0
 windows_service_state{name="wpnservice",state="stop pending"} 0
 windows_service_state{name="wpnservice",state="stopped"} 0
 windows_service_state{name="wpnservice",state="unknown"} 0
-windows_service_state{name="wpnuserservice_225e3",state="continue pending"} 0
-windows_service_state{name="wpnuserservice_225e3",state="pause pending"} 0
-windows_service_state{name="wpnuserservice_225e3",state="paused"} 0
-windows_service_state{name="wpnuserservice_225e3",state="running"} 0
-windows_service_state{name="wpnuserservice_225e3",state="start pending"} 0
-windows_service_state{name="wpnuserservice_225e3",state="stop pending"} 0
-windows_service_state{name="wpnuserservice_225e3",state="stopped"} 1
-windows_service_state{name="wpnuserservice_225e3",state="unknown"} 0
+windows_service_state{name="wpnuserservice_390e7",state="continue pending"} 0
+windows_service_state{name="wpnuserservice_390e7",state="pause pending"} 0
+windows_service_state{name="wpnuserservice_390e7",state="paused"} 0
+windows_service_state{name="wpnuserservice_390e7",state="running"} 1
+windows_service_state{name="wpnuserservice_390e7",state="start pending"} 0
+windows_service_state{name="wpnuserservice_390e7",state="stop pending"} 0
+windows_service_state{name="wpnuserservice_390e7",state="stopped"} 0
+windows_service_state{name="wpnuserservice_390e7",state="unknown"} 0
+windows_service_state{name="wscsvc",state="continue pending"} 0
+windows_service_state{name="wscsvc",state="pause pending"} 0
+windows_service_state{name="wscsvc",state="paused"} 0
+windows_service_state{name="wscsvc",state="running"} 1
+windows_service_state{name="wscsvc",state="start pending"} 0
+windows_service_state{name="wscsvc",state="stop pending"} 0
+windows_service_state{name="wscsvc",state="stopped"} 0
+windows_service_state{name="wscsvc",state="unknown"} 0
 windows_service_state{name="wsearch",state="continue pending"} 0
 windows_service_state{name="wsearch",state="pause pending"} 0
 windows_service_state{name="wsearch",state="paused"} 0
-windows_service_state{name="wsearch",state="running"} 0
+windows_service_state{name="wsearch",state="running"} 1
 windows_service_state{name="wsearch",state="start pending"} 0
 windows_service_state{name="wsearch",state="stop pending"} 0
-windows_service_state{name="wsearch",state="stopped"} 1
+windows_service_state{name="wsearch",state="stopped"} 0
 windows_service_state{name="wsearch",state="unknown"} 0
 windows_service_state{name="wuauserv",state="continue pending"} 0
 windows_service_state{name="wuauserv",state="pause pending"} 0
 windows_service_state{name="wuauserv",state="paused"} 0
-windows_service_state{name="wuauserv",state="running"} 0
+windows_service_state{name="wuauserv",state="running"} 1
 windows_service_state{name="wuauserv",state="start pending"} 0
 windows_service_state{name="wuauserv",state="stop pending"} 0
-windows_service_state{name="wuauserv",state="stopped"} 1
+windows_service_state{name="wuauserv",state="stopped"} 0
 windows_service_state{name="wuauserv",state="unknown"} 0
-windows_service_state{name="wudfsvc",state="continue pending"} 0
-windows_service_state{name="wudfsvc",state="pause pending"} 0
-windows_service_state{name="wudfsvc",state="paused"} 0
-windows_service_state{name="wudfsvc",state="running"} 0
-windows_service_state{name="wudfsvc",state="start pending"} 0
-windows_service_state{name="wudfsvc",state="stop pending"} 0
-windows_service_state{name="wudfsvc",state="stopped"} 1
-windows_service_state{name="wudfsvc",state="unknown"} 0
+windows_service_state{name="wwansvc",state="continue pending"} 0
+windows_service_state{name="wwansvc",state="pause pending"} 0
+windows_service_state{name="wwansvc",state="paused"} 0
+windows_service_state{name="wwansvc",state="running"} 0
+windows_service_state{name="wwansvc",state="start pending"} 0
+windows_service_state{name="wwansvc",state="stop pending"} 0
+windows_service_state{name="wwansvc",state="stopped"} 1
+windows_service_state{name="wwansvc",state="unknown"} 0
 windows_service_state{name="xblauthmanager",state="continue pending"} 0
 windows_service_state{name="xblauthmanager",state="pause pending"} 0
 windows_service_state{name="xblauthmanager",state="paused"} 0
@@ -2854,8 +3664,36 @@ windows_service_state{name="xblgamesave",state="start pending"} 0
 windows_service_state{name="xblgamesave",state="stop pending"} 0
 windows_service_state{name="xblgamesave",state="stopped"} 1
 windows_service_state{name="xblgamesave",state="unknown"} 0
+windows_service_state{name="xboxgipsvc",state="continue pending"} 0
+windows_service_state{name="xboxgipsvc",state="pause pending"} 0
+windows_service_state{name="xboxgipsvc",state="paused"} 0
+windows_service_state{name="xboxgipsvc",state="running"} 0
+windows_service_state{name="xboxgipsvc",state="start pending"} 0
+windows_service_state{name="xboxgipsvc",state="stop pending"} 0
+windows_service_state{name="xboxgipsvc",state="stopped"} 1
+windows_service_state{name="xboxgipsvc",state="unknown"} 0
+windows_service_state{name="xboxnetapisvc",state="continue pending"} 0
+windows_service_state{name="xboxnetapisvc",state="pause pending"} 0
+windows_service_state{name="xboxnetapisvc",state="paused"} 0
+windows_service_state{name="xboxnetapisvc",state="running"} 0
+windows_service_state{name="xboxnetapisvc",state="start pending"} 0
+windows_service_state{name="xboxnetapisvc",state="stop pending"} 0
+windows_service_state{name="xboxnetapisvc",state="stopped"} 1
+windows_service_state{name="xboxnetapisvc",state="unknown"} 0
 # HELP windows_service_status The status of the service (Status)
 # TYPE windows_service_status gauge
+windows_service_status{name="aarsvc_390e7",status="degraded"} 0
+windows_service_status{name="aarsvc_390e7",status="error"} 0
+windows_service_status{name="aarsvc_390e7",status="lost comm"} 0
+windows_service_status{name="aarsvc_390e7",status="no contact"} 0
+windows_service_status{name="aarsvc_390e7",status="nonrecover"} 0
+windows_service_status{name="aarsvc_390e7",status="ok"} 1
+windows_service_status{name="aarsvc_390e7",status="pred fail"} 0
+windows_service_status{name="aarsvc_390e7",status="service"} 0
+windows_service_status{name="aarsvc_390e7",status="starting"} 0
+windows_service_status{name="aarsvc_390e7",status="stopping"} 0
+windows_service_status{name="aarsvc_390e7",status="stressed"} 0
+windows_service_status{name="aarsvc_390e7",status="unknown"} 0
 windows_service_status{name="ajrouter",status="degraded"} 0
 windows_service_status{name="ajrouter",status="error"} 0
 windows_service_status{name="ajrouter",status="lost comm"} 0
@@ -2880,18 +3718,6 @@ windows_service_status{name="alg",status="starting"} 0
 windows_service_status{name="alg",status="stopping"} 0
 windows_service_status{name="alg",status="stressed"} 0
 windows_service_status{name="alg",status="unknown"} 0
-windows_service_status{name="apphostsvc",status="degraded"} 0
-windows_service_status{name="apphostsvc",status="error"} 0
-windows_service_status{name="apphostsvc",status="lost comm"} 0
-windows_service_status{name="apphostsvc",status="no contact"} 0
-windows_service_status{name="apphostsvc",status="nonrecover"} 0
-windows_service_status{name="apphostsvc",status="ok"} 1
-windows_service_status{name="apphostsvc",status="pred fail"} 0
-windows_service_status{name="apphostsvc",status="service"} 0
-windows_service_status{name="apphostsvc",status="starting"} 0
-windows_service_status{name="apphostsvc",status="stopping"} 0
-windows_service_status{name="apphostsvc",status="stressed"} 0
-windows_service_status{name="apphostsvc",status="unknown"} 0
 windows_service_status{name="appidsvc",status="degraded"} 0
 windows_service_status{name="appidsvc",status="error"} 0
 windows_service_status{name="appidsvc",status="lost comm"} 0
@@ -2964,6 +3790,18 @@ windows_service_status{name="appxsvc",status="starting"} 0
 windows_service_status{name="appxsvc",status="stopping"} 0
 windows_service_status{name="appxsvc",status="stressed"} 0
 windows_service_status{name="appxsvc",status="unknown"} 0
+windows_service_status{name="assignedaccessmanagersvc",status="degraded"} 0
+windows_service_status{name="assignedaccessmanagersvc",status="error"} 0
+windows_service_status{name="assignedaccessmanagersvc",status="lost comm"} 0
+windows_service_status{name="assignedaccessmanagersvc",status="no contact"} 0
+windows_service_status{name="assignedaccessmanagersvc",status="nonrecover"} 0
+windows_service_status{name="assignedaccessmanagersvc",status="ok"} 1
+windows_service_status{name="assignedaccessmanagersvc",status="pred fail"} 0
+windows_service_status{name="assignedaccessmanagersvc",status="service"} 0
+windows_service_status{name="assignedaccessmanagersvc",status="starting"} 0
+windows_service_status{name="assignedaccessmanagersvc",status="stopping"} 0
+windows_service_status{name="assignedaccessmanagersvc",status="stressed"} 0
+windows_service_status{name="assignedaccessmanagersvc",status="unknown"} 0
 windows_service_status{name="audioendpointbuilder",status="degraded"} 0
 windows_service_status{name="audioendpointbuilder",status="error"} 0
 windows_service_status{name="audioendpointbuilder",status="lost comm"} 0
@@ -2988,6 +3826,18 @@ windows_service_status{name="audiosrv",status="starting"} 0
 windows_service_status{name="audiosrv",status="stopping"} 0
 windows_service_status{name="audiosrv",status="stressed"} 0
 windows_service_status{name="audiosrv",status="unknown"} 0
+windows_service_status{name="autotimesvc",status="degraded"} 0
+windows_service_status{name="autotimesvc",status="error"} 0
+windows_service_status{name="autotimesvc",status="lost comm"} 0
+windows_service_status{name="autotimesvc",status="no contact"} 0
+windows_service_status{name="autotimesvc",status="nonrecover"} 0
+windows_service_status{name="autotimesvc",status="ok"} 1
+windows_service_status{name="autotimesvc",status="pred fail"} 0
+windows_service_status{name="autotimesvc",status="service"} 0
+windows_service_status{name="autotimesvc",status="starting"} 0
+windows_service_status{name="autotimesvc",status="stopping"} 0
+windows_service_status{name="autotimesvc",status="stressed"} 0
+windows_service_status{name="autotimesvc",status="unknown"} 0
 windows_service_status{name="axinstsv",status="degraded"} 0
 windows_service_status{name="axinstsv",status="error"} 0
 windows_service_status{name="axinstsv",status="lost comm"} 0
@@ -3000,6 +3850,30 @@ windows_service_status{name="axinstsv",status="starting"} 0
 windows_service_status{name="axinstsv",status="stopping"} 0
 windows_service_status{name="axinstsv",status="stressed"} 0
 windows_service_status{name="axinstsv",status="unknown"} 0
+windows_service_status{name="bcastdvruserservice_390e7",status="degraded"} 0
+windows_service_status{name="bcastdvruserservice_390e7",status="error"} 0
+windows_service_status{name="bcastdvruserservice_390e7",status="lost comm"} 0
+windows_service_status{name="bcastdvruserservice_390e7",status="no contact"} 0
+windows_service_status{name="bcastdvruserservice_390e7",status="nonrecover"} 0
+windows_service_status{name="bcastdvruserservice_390e7",status="ok"} 1
+windows_service_status{name="bcastdvruserservice_390e7",status="pred fail"} 0
+windows_service_status{name="bcastdvruserservice_390e7",status="service"} 0
+windows_service_status{name="bcastdvruserservice_390e7",status="starting"} 0
+windows_service_status{name="bcastdvruserservice_390e7",status="stopping"} 0
+windows_service_status{name="bcastdvruserservice_390e7",status="stressed"} 0
+windows_service_status{name="bcastdvruserservice_390e7",status="unknown"} 0
+windows_service_status{name="bdesvc",status="degraded"} 0
+windows_service_status{name="bdesvc",status="error"} 0
+windows_service_status{name="bdesvc",status="lost comm"} 0
+windows_service_status{name="bdesvc",status="no contact"} 0
+windows_service_status{name="bdesvc",status="nonrecover"} 0
+windows_service_status{name="bdesvc",status="ok"} 1
+windows_service_status{name="bdesvc",status="pred fail"} 0
+windows_service_status{name="bdesvc",status="service"} 0
+windows_service_status{name="bdesvc",status="starting"} 0
+windows_service_status{name="bdesvc",status="stopping"} 0
+windows_service_status{name="bdesvc",status="stressed"} 0
+windows_service_status{name="bdesvc",status="unknown"} 0
 windows_service_status{name="bfe",status="degraded"} 0
 windows_service_status{name="bfe",status="error"} 0
 windows_service_status{name="bfe",status="lost comm"} 0
@@ -3024,6 +3898,18 @@ windows_service_status{name="bits",status="starting"} 0
 windows_service_status{name="bits",status="stopping"} 0
 windows_service_status{name="bits",status="stressed"} 0
 windows_service_status{name="bits",status="unknown"} 0
+windows_service_status{name="bluetoothuserservice_390e7",status="degraded"} 0
+windows_service_status{name="bluetoothuserservice_390e7",status="error"} 0
+windows_service_status{name="bluetoothuserservice_390e7",status="lost comm"} 0
+windows_service_status{name="bluetoothuserservice_390e7",status="no contact"} 0
+windows_service_status{name="bluetoothuserservice_390e7",status="nonrecover"} 0
+windows_service_status{name="bluetoothuserservice_390e7",status="ok"} 1
+windows_service_status{name="bluetoothuserservice_390e7",status="pred fail"} 0
+windows_service_status{name="bluetoothuserservice_390e7",status="service"} 0
+windows_service_status{name="bluetoothuserservice_390e7",status="starting"} 0
+windows_service_status{name="bluetoothuserservice_390e7",status="stopping"} 0
+windows_service_status{name="bluetoothuserservice_390e7",status="stressed"} 0
+windows_service_status{name="bluetoothuserservice_390e7",status="unknown"} 0
 windows_service_status{name="brokerinfrastructure",status="degraded"} 0
 windows_service_status{name="brokerinfrastructure",status="error"} 0
 windows_service_status{name="brokerinfrastructure",status="lost comm"} 0
@@ -3036,18 +3922,30 @@ windows_service_status{name="brokerinfrastructure",status="starting"} 0
 windows_service_status{name="brokerinfrastructure",status="stopping"} 0
 windows_service_status{name="brokerinfrastructure",status="stressed"} 0
 windows_service_status{name="brokerinfrastructure",status="unknown"} 0
-windows_service_status{name="browser",status="degraded"} 0
-windows_service_status{name="browser",status="error"} 0
-windows_service_status{name="browser",status="lost comm"} 0
-windows_service_status{name="browser",status="no contact"} 0
-windows_service_status{name="browser",status="nonrecover"} 0
-windows_service_status{name="browser",status="ok"} 1
-windows_service_status{name="browser",status="pred fail"} 0
-windows_service_status{name="browser",status="service"} 0
-windows_service_status{name="browser",status="starting"} 0
-windows_service_status{name="browser",status="stopping"} 0
-windows_service_status{name="browser",status="stressed"} 0
-windows_service_status{name="browser",status="unknown"} 0
+windows_service_status{name="btagservice",status="degraded"} 0
+windows_service_status{name="btagservice",status="error"} 0
+windows_service_status{name="btagservice",status="lost comm"} 0
+windows_service_status{name="btagservice",status="no contact"} 0
+windows_service_status{name="btagservice",status="nonrecover"} 0
+windows_service_status{name="btagservice",status="ok"} 1
+windows_service_status{name="btagservice",status="pred fail"} 0
+windows_service_status{name="btagservice",status="service"} 0
+windows_service_status{name="btagservice",status="starting"} 0
+windows_service_status{name="btagservice",status="stopping"} 0
+windows_service_status{name="btagservice",status="stressed"} 0
+windows_service_status{name="btagservice",status="unknown"} 0
+windows_service_status{name="bthavctpsvc",status="degraded"} 0
+windows_service_status{name="bthavctpsvc",status="error"} 0
+windows_service_status{name="bthavctpsvc",status="lost comm"} 0
+windows_service_status{name="bthavctpsvc",status="no contact"} 0
+windows_service_status{name="bthavctpsvc",status="nonrecover"} 0
+windows_service_status{name="bthavctpsvc",status="ok"} 1
+windows_service_status{name="bthavctpsvc",status="pred fail"} 0
+windows_service_status{name="bthavctpsvc",status="service"} 0
+windows_service_status{name="bthavctpsvc",status="starting"} 0
+windows_service_status{name="bthavctpsvc",status="stopping"} 0
+windows_service_status{name="bthavctpsvc",status="stressed"} 0
+windows_service_status{name="bthavctpsvc",status="unknown"} 0
 windows_service_status{name="bthserv",status="degraded"} 0
 windows_service_status{name="bthserv",status="error"} 0
 windows_service_status{name="bthserv",status="lost comm"} 0
@@ -3060,6 +3958,42 @@ windows_service_status{name="bthserv",status="starting"} 0
 windows_service_status{name="bthserv",status="stopping"} 0
 windows_service_status{name="bthserv",status="stressed"} 0
 windows_service_status{name="bthserv",status="unknown"} 0
+windows_service_status{name="camsvc",status="degraded"} 0
+windows_service_status{name="camsvc",status="error"} 0
+windows_service_status{name="camsvc",status="lost comm"} 0
+windows_service_status{name="camsvc",status="no contact"} 0
+windows_service_status{name="camsvc",status="nonrecover"} 0
+windows_service_status{name="camsvc",status="ok"} 1
+windows_service_status{name="camsvc",status="pred fail"} 0
+windows_service_status{name="camsvc",status="service"} 0
+windows_service_status{name="camsvc",status="starting"} 0
+windows_service_status{name="camsvc",status="stopping"} 0
+windows_service_status{name="camsvc",status="stressed"} 0
+windows_service_status{name="camsvc",status="unknown"} 0
+windows_service_status{name="captureservice_390e7",status="degraded"} 0
+windows_service_status{name="captureservice_390e7",status="error"} 0
+windows_service_status{name="captureservice_390e7",status="lost comm"} 0
+windows_service_status{name="captureservice_390e7",status="no contact"} 0
+windows_service_status{name="captureservice_390e7",status="nonrecover"} 0
+windows_service_status{name="captureservice_390e7",status="ok"} 1
+windows_service_status{name="captureservice_390e7",status="pred fail"} 0
+windows_service_status{name="captureservice_390e7",status="service"} 0
+windows_service_status{name="captureservice_390e7",status="starting"} 0
+windows_service_status{name="captureservice_390e7",status="stopping"} 0
+windows_service_status{name="captureservice_390e7",status="stressed"} 0
+windows_service_status{name="captureservice_390e7",status="unknown"} 0
+windows_service_status{name="cbdhsvc_390e7",status="degraded"} 0
+windows_service_status{name="cbdhsvc_390e7",status="error"} 0
+windows_service_status{name="cbdhsvc_390e7",status="lost comm"} 0
+windows_service_status{name="cbdhsvc_390e7",status="no contact"} 0
+windows_service_status{name="cbdhsvc_390e7",status="nonrecover"} 0
+windows_service_status{name="cbdhsvc_390e7",status="ok"} 1
+windows_service_status{name="cbdhsvc_390e7",status="pred fail"} 0
+windows_service_status{name="cbdhsvc_390e7",status="service"} 0
+windows_service_status{name="cbdhsvc_390e7",status="starting"} 0
+windows_service_status{name="cbdhsvc_390e7",status="stopping"} 0
+windows_service_status{name="cbdhsvc_390e7",status="stressed"} 0
+windows_service_status{name="cbdhsvc_390e7",status="unknown"} 0
 windows_service_status{name="cdpsvc",status="degraded"} 0
 windows_service_status{name="cdpsvc",status="error"} 0
 windows_service_status{name="cdpsvc",status="lost comm"} 0
@@ -3072,18 +4006,18 @@ windows_service_status{name="cdpsvc",status="starting"} 0
 windows_service_status{name="cdpsvc",status="stopping"} 0
 windows_service_status{name="cdpsvc",status="stressed"} 0
 windows_service_status{name="cdpsvc",status="unknown"} 0
-windows_service_status{name="cdpusersvc_225e3",status="degraded"} 0
-windows_service_status{name="cdpusersvc_225e3",status="error"} 0
-windows_service_status{name="cdpusersvc_225e3",status="lost comm"} 0
-windows_service_status{name="cdpusersvc_225e3",status="no contact"} 0
-windows_service_status{name="cdpusersvc_225e3",status="nonrecover"} 0
-windows_service_status{name="cdpusersvc_225e3",status="ok"} 1
-windows_service_status{name="cdpusersvc_225e3",status="pred fail"} 0
-windows_service_status{name="cdpusersvc_225e3",status="service"} 0
-windows_service_status{name="cdpusersvc_225e3",status="starting"} 0
-windows_service_status{name="cdpusersvc_225e3",status="stopping"} 0
-windows_service_status{name="cdpusersvc_225e3",status="stressed"} 0
-windows_service_status{name="cdpusersvc_225e3",status="unknown"} 0
+windows_service_status{name="cdpusersvc_390e7",status="degraded"} 0
+windows_service_status{name="cdpusersvc_390e7",status="error"} 0
+windows_service_status{name="cdpusersvc_390e7",status="lost comm"} 0
+windows_service_status{name="cdpusersvc_390e7",status="no contact"} 0
+windows_service_status{name="cdpusersvc_390e7",status="nonrecover"} 0
+windows_service_status{name="cdpusersvc_390e7",status="ok"} 1
+windows_service_status{name="cdpusersvc_390e7",status="pred fail"} 0
+windows_service_status{name="cdpusersvc_390e7",status="service"} 0
+windows_service_status{name="cdpusersvc_390e7",status="starting"} 0
+windows_service_status{name="cdpusersvc_390e7",status="stopping"} 0
+windows_service_status{name="cdpusersvc_390e7",status="stressed"} 0
+windows_service_status{name="cdpusersvc_390e7",status="unknown"} 0
 windows_service_status{name="certpropsvc",status="degraded"} 0
 windows_service_status{name="certpropsvc",status="error"} 0
 windows_service_status{name="certpropsvc",status="lost comm"} 0
@@ -3120,6 +4054,18 @@ windows_service_status{name="comsysapp",status="starting"} 0
 windows_service_status{name="comsysapp",status="stopping"} 0
 windows_service_status{name="comsysapp",status="stressed"} 0
 windows_service_status{name="comsysapp",status="unknown"} 0
+windows_service_status{name="consentuxusersvc_390e7",status="degraded"} 0
+windows_service_status{name="consentuxusersvc_390e7",status="error"} 0
+windows_service_status{name="consentuxusersvc_390e7",status="lost comm"} 0
+windows_service_status{name="consentuxusersvc_390e7",status="no contact"} 0
+windows_service_status{name="consentuxusersvc_390e7",status="nonrecover"} 0
+windows_service_status{name="consentuxusersvc_390e7",status="ok"} 1
+windows_service_status{name="consentuxusersvc_390e7",status="pred fail"} 0
+windows_service_status{name="consentuxusersvc_390e7",status="service"} 0
+windows_service_status{name="consentuxusersvc_390e7",status="starting"} 0
+windows_service_status{name="consentuxusersvc_390e7",status="stopping"} 0
+windows_service_status{name="consentuxusersvc_390e7",status="stressed"} 0
+windows_service_status{name="consentuxusersvc_390e7",status="unknown"} 0
 windows_service_status{name="coremessagingregistrar",status="degraded"} 0
 windows_service_status{name="coremessagingregistrar",status="error"} 0
 windows_service_status{name="coremessagingregistrar",status="lost comm"} 0
@@ -3132,6 +4078,18 @@ windows_service_status{name="coremessagingregistrar",status="starting"} 0
 windows_service_status{name="coremessagingregistrar",status="stopping"} 0
 windows_service_status{name="coremessagingregistrar",status="stressed"} 0
 windows_service_status{name="coremessagingregistrar",status="unknown"} 0
+windows_service_status{name="credentialenrollmentmanagerusersvc_390e7",status="degraded"} 0
+windows_service_status{name="credentialenrollmentmanagerusersvc_390e7",status="error"} 0
+windows_service_status{name="credentialenrollmentmanagerusersvc_390e7",status="lost comm"} 0
+windows_service_status{name="credentialenrollmentmanagerusersvc_390e7",status="no contact"} 0
+windows_service_status{name="credentialenrollmentmanagerusersvc_390e7",status="nonrecover"} 0
+windows_service_status{name="credentialenrollmentmanagerusersvc_390e7",status="ok"} 1
+windows_service_status{name="credentialenrollmentmanagerusersvc_390e7",status="pred fail"} 0
+windows_service_status{name="credentialenrollmentmanagerusersvc_390e7",status="service"} 0
+windows_service_status{name="credentialenrollmentmanagerusersvc_390e7",status="starting"} 0
+windows_service_status{name="credentialenrollmentmanagerusersvc_390e7",status="stopping"} 0
+windows_service_status{name="credentialenrollmentmanagerusersvc_390e7",status="stressed"} 0
+windows_service_status{name="credentialenrollmentmanagerusersvc_390e7",status="unknown"} 0
 windows_service_status{name="cryptsvc",status="degraded"} 0
 windows_service_status{name="cryptsvc",status="error"} 0
 windows_service_status{name="cryptsvc",status="lost comm"} 0
@@ -3168,18 +4126,6 @@ windows_service_status{name="dcomlaunch",status="starting"} 0
 windows_service_status{name="dcomlaunch",status="stopping"} 0
 windows_service_status{name="dcomlaunch",status="stressed"} 0
 windows_service_status{name="dcomlaunch",status="unknown"} 0
-windows_service_status{name="dcpsvc",status="degraded"} 0
-windows_service_status{name="dcpsvc",status="error"} 0
-windows_service_status{name="dcpsvc",status="lost comm"} 0
-windows_service_status{name="dcpsvc",status="no contact"} 0
-windows_service_status{name="dcpsvc",status="nonrecover"} 0
-windows_service_status{name="dcpsvc",status="ok"} 1
-windows_service_status{name="dcpsvc",status="pred fail"} 0
-windows_service_status{name="dcpsvc",status="service"} 0
-windows_service_status{name="dcpsvc",status="starting"} 0
-windows_service_status{name="dcpsvc",status="stopping"} 0
-windows_service_status{name="dcpsvc",status="stressed"} 0
-windows_service_status{name="dcpsvc",status="unknown"} 0
 windows_service_status{name="defragsvc",status="degraded"} 0
 windows_service_status{name="defragsvc",status="error"} 0
 windows_service_status{name="defragsvc",status="lost comm"} 0
@@ -3192,6 +4138,18 @@ windows_service_status{name="defragsvc",status="starting"} 0
 windows_service_status{name="defragsvc",status="stopping"} 0
 windows_service_status{name="defragsvc",status="stressed"} 0
 windows_service_status{name="defragsvc",status="unknown"} 0
+windows_service_status{name="deviceassociationbrokersvc_390e7",status="degraded"} 0
+windows_service_status{name="deviceassociationbrokersvc_390e7",status="error"} 0
+windows_service_status{name="deviceassociationbrokersvc_390e7",status="lost comm"} 0
+windows_service_status{name="deviceassociationbrokersvc_390e7",status="no contact"} 0
+windows_service_status{name="deviceassociationbrokersvc_390e7",status="nonrecover"} 0
+windows_service_status{name="deviceassociationbrokersvc_390e7",status="ok"} 1
+windows_service_status{name="deviceassociationbrokersvc_390e7",status="pred fail"} 0
+windows_service_status{name="deviceassociationbrokersvc_390e7",status="service"} 0
+windows_service_status{name="deviceassociationbrokersvc_390e7",status="starting"} 0
+windows_service_status{name="deviceassociationbrokersvc_390e7",status="stopping"} 0
+windows_service_status{name="deviceassociationbrokersvc_390e7",status="stressed"} 0
+windows_service_status{name="deviceassociationbrokersvc_390e7",status="unknown"} 0
 windows_service_status{name="deviceassociationservice",status="degraded"} 0
 windows_service_status{name="deviceassociationservice",status="error"} 0
 windows_service_status{name="deviceassociationservice",status="lost comm"} 0
@@ -3216,6 +4174,30 @@ windows_service_status{name="deviceinstall",status="starting"} 0
 windows_service_status{name="deviceinstall",status="stopping"} 0
 windows_service_status{name="deviceinstall",status="stressed"} 0
 windows_service_status{name="deviceinstall",status="unknown"} 0
+windows_service_status{name="devicepickerusersvc_390e7",status="degraded"} 0
+windows_service_status{name="devicepickerusersvc_390e7",status="error"} 0
+windows_service_status{name="devicepickerusersvc_390e7",status="lost comm"} 0
+windows_service_status{name="devicepickerusersvc_390e7",status="no contact"} 0
+windows_service_status{name="devicepickerusersvc_390e7",status="nonrecover"} 0
+windows_service_status{name="devicepickerusersvc_390e7",status="ok"} 1
+windows_service_status{name="devicepickerusersvc_390e7",status="pred fail"} 0
+windows_service_status{name="devicepickerusersvc_390e7",status="service"} 0
+windows_service_status{name="devicepickerusersvc_390e7",status="starting"} 0
+windows_service_status{name="devicepickerusersvc_390e7",status="stopping"} 0
+windows_service_status{name="devicepickerusersvc_390e7",status="stressed"} 0
+windows_service_status{name="devicepickerusersvc_390e7",status="unknown"} 0
+windows_service_status{name="devicesflowusersvc_390e7",status="degraded"} 0
+windows_service_status{name="devicesflowusersvc_390e7",status="error"} 0
+windows_service_status{name="devicesflowusersvc_390e7",status="lost comm"} 0
+windows_service_status{name="devicesflowusersvc_390e7",status="no contact"} 0
+windows_service_status{name="devicesflowusersvc_390e7",status="nonrecover"} 0
+windows_service_status{name="devicesflowusersvc_390e7",status="ok"} 1
+windows_service_status{name="devicesflowusersvc_390e7",status="pred fail"} 0
+windows_service_status{name="devicesflowusersvc_390e7",status="service"} 0
+windows_service_status{name="devicesflowusersvc_390e7",status="starting"} 0
+windows_service_status{name="devicesflowusersvc_390e7",status="stopping"} 0
+windows_service_status{name="devicesflowusersvc_390e7",status="stressed"} 0
+windows_service_status{name="devicesflowusersvc_390e7",status="unknown"} 0
 windows_service_status{name="devquerybroker",status="degraded"} 0
 windows_service_status{name="devquerybroker",status="error"} 0
 windows_service_status{name="devquerybroker",status="lost comm"} 0
@@ -3252,6 +4234,18 @@ windows_service_status{name="diagnosticshub.standardcollector.service",status="s
 windows_service_status{name="diagnosticshub.standardcollector.service",status="stopping"} 0
 windows_service_status{name="diagnosticshub.standardcollector.service",status="stressed"} 0
 windows_service_status{name="diagnosticshub.standardcollector.service",status="unknown"} 0
+windows_service_status{name="diagsvc",status="degraded"} 0
+windows_service_status{name="diagsvc",status="error"} 0
+windows_service_status{name="diagsvc",status="lost comm"} 0
+windows_service_status{name="diagsvc",status="no contact"} 0
+windows_service_status{name="diagsvc",status="nonrecover"} 0
+windows_service_status{name="diagsvc",status="ok"} 1
+windows_service_status{name="diagsvc",status="pred fail"} 0
+windows_service_status{name="diagsvc",status="service"} 0
+windows_service_status{name="diagsvc",status="starting"} 0
+windows_service_status{name="diagsvc",status="stopping"} 0
+windows_service_status{name="diagsvc",status="stressed"} 0
+windows_service_status{name="diagsvc",status="unknown"} 0
 windows_service_status{name="diagtrack",status="degraded"} 0
 windows_service_status{name="diagtrack",status="error"} 0
 windows_service_status{name="diagtrack",status="lost comm"} 0
@@ -3264,6 +4258,30 @@ windows_service_status{name="diagtrack",status="starting"} 0
 windows_service_status{name="diagtrack",status="stopping"} 0
 windows_service_status{name="diagtrack",status="stressed"} 0
 windows_service_status{name="diagtrack",status="unknown"} 0
+windows_service_status{name="dispbrokerdesktopsvc",status="degraded"} 0
+windows_service_status{name="dispbrokerdesktopsvc",status="error"} 0
+windows_service_status{name="dispbrokerdesktopsvc",status="lost comm"} 0
+windows_service_status{name="dispbrokerdesktopsvc",status="no contact"} 0
+windows_service_status{name="dispbrokerdesktopsvc",status="nonrecover"} 0
+windows_service_status{name="dispbrokerdesktopsvc",status="ok"} 1
+windows_service_status{name="dispbrokerdesktopsvc",status="pred fail"} 0
+windows_service_status{name="dispbrokerdesktopsvc",status="service"} 0
+windows_service_status{name="dispbrokerdesktopsvc",status="starting"} 0
+windows_service_status{name="dispbrokerdesktopsvc",status="stopping"} 0
+windows_service_status{name="dispbrokerdesktopsvc",status="stressed"} 0
+windows_service_status{name="dispbrokerdesktopsvc",status="unknown"} 0
+windows_service_status{name="displayenhancementservice",status="degraded"} 0
+windows_service_status{name="displayenhancementservice",status="error"} 0
+windows_service_status{name="displayenhancementservice",status="lost comm"} 0
+windows_service_status{name="displayenhancementservice",status="no contact"} 0
+windows_service_status{name="displayenhancementservice",status="nonrecover"} 0
+windows_service_status{name="displayenhancementservice",status="ok"} 1
+windows_service_status{name="displayenhancementservice",status="pred fail"} 0
+windows_service_status{name="displayenhancementservice",status="service"} 0
+windows_service_status{name="displayenhancementservice",status="starting"} 0
+windows_service_status{name="displayenhancementservice",status="stopping"} 0
+windows_service_status{name="displayenhancementservice",status="stressed"} 0
+windows_service_status{name="displayenhancementservice",status="unknown"} 0
 windows_service_status{name="dmenrollmentsvc",status="degraded"} 0
 windows_service_status{name="dmenrollmentsvc",status="error"} 0
 windows_service_status{name="dmenrollmentsvc",status="lost comm"} 0
@@ -3300,6 +4318,18 @@ windows_service_status{name="dnscache",status="starting"} 0
 windows_service_status{name="dnscache",status="stopping"} 0
 windows_service_status{name="dnscache",status="stressed"} 0
 windows_service_status{name="dnscache",status="unknown"} 0
+windows_service_status{name="dosvc",status="degraded"} 0
+windows_service_status{name="dosvc",status="error"} 0
+windows_service_status{name="dosvc",status="lost comm"} 0
+windows_service_status{name="dosvc",status="no contact"} 0
+windows_service_status{name="dosvc",status="nonrecover"} 0
+windows_service_status{name="dosvc",status="ok"} 1
+windows_service_status{name="dosvc",status="pred fail"} 0
+windows_service_status{name="dosvc",status="service"} 0
+windows_service_status{name="dosvc",status="starting"} 0
+windows_service_status{name="dosvc",status="stopping"} 0
+windows_service_status{name="dosvc",status="stressed"} 0
+windows_service_status{name="dosvc",status="unknown"} 0
 windows_service_status{name="dot3svc",status="degraded"} 0
 windows_service_status{name="dot3svc",status="error"} 0
 windows_service_status{name="dot3svc",status="lost comm"} 0
@@ -3348,6 +4378,18 @@ windows_service_status{name="dssvc",status="starting"} 0
 windows_service_status{name="dssvc",status="stopping"} 0
 windows_service_status{name="dssvc",status="stressed"} 0
 windows_service_status{name="dssvc",status="unknown"} 0
+windows_service_status{name="dusmsvc",status="degraded"} 0
+windows_service_status{name="dusmsvc",status="error"} 0
+windows_service_status{name="dusmsvc",status="lost comm"} 0
+windows_service_status{name="dusmsvc",status="no contact"} 0
+windows_service_status{name="dusmsvc",status="nonrecover"} 0
+windows_service_status{name="dusmsvc",status="ok"} 1
+windows_service_status{name="dusmsvc",status="pred fail"} 0
+windows_service_status{name="dusmsvc",status="service"} 0
+windows_service_status{name="dusmsvc",status="starting"} 0
+windows_service_status{name="dusmsvc",status="stopping"} 0
+windows_service_status{name="dusmsvc",status="stressed"} 0
+windows_service_status{name="dusmsvc",status="unknown"} 0
 windows_service_status{name="eaphost",status="degraded"} 0
 windows_service_status{name="eaphost",status="error"} 0
 windows_service_status{name="eaphost",status="lost comm"} 0
@@ -3420,6 +4462,18 @@ windows_service_status{name="eventsystem",status="starting"} 0
 windows_service_status{name="eventsystem",status="stopping"} 0
 windows_service_status{name="eventsystem",status="stressed"} 0
 windows_service_status{name="eventsystem",status="unknown"} 0
+windows_service_status{name="fax",status="degraded"} 0
+windows_service_status{name="fax",status="error"} 0
+windows_service_status{name="fax",status="lost comm"} 0
+windows_service_status{name="fax",status="no contact"} 0
+windows_service_status{name="fax",status="nonrecover"} 0
+windows_service_status{name="fax",status="ok"} 1
+windows_service_status{name="fax",status="pred fail"} 0
+windows_service_status{name="fax",status="service"} 0
+windows_service_status{name="fax",status="starting"} 0
+windows_service_status{name="fax",status="stopping"} 0
+windows_service_status{name="fax",status="stressed"} 0
+windows_service_status{name="fax",status="unknown"} 0
 windows_service_status{name="fdphost",status="degraded"} 0
 windows_service_status{name="fdphost",status="error"} 0
 windows_service_status{name="fdphost",status="lost comm"} 0
@@ -3444,6 +4498,18 @@ windows_service_status{name="fdrespub",status="starting"} 0
 windows_service_status{name="fdrespub",status="stopping"} 0
 windows_service_status{name="fdrespub",status="stressed"} 0
 windows_service_status{name="fdrespub",status="unknown"} 0
+windows_service_status{name="fhsvc",status="degraded"} 0
+windows_service_status{name="fhsvc",status="error"} 0
+windows_service_status{name="fhsvc",status="lost comm"} 0
+windows_service_status{name="fhsvc",status="no contact"} 0
+windows_service_status{name="fhsvc",status="nonrecover"} 0
+windows_service_status{name="fhsvc",status="ok"} 1
+windows_service_status{name="fhsvc",status="pred fail"} 0
+windows_service_status{name="fhsvc",status="service"} 0
+windows_service_status{name="fhsvc",status="starting"} 0
+windows_service_status{name="fhsvc",status="stopping"} 0
+windows_service_status{name="fhsvc",status="stressed"} 0
+windows_service_status{name="fhsvc",status="unknown"} 0
 windows_service_status{name="fontcache",status="degraded"} 0
 windows_service_status{name="fontcache",status="error"} 0
 windows_service_status{name="fontcache",status="lost comm"} 0
@@ -3456,6 +4522,18 @@ windows_service_status{name="fontcache",status="starting"} 0
 windows_service_status{name="fontcache",status="stopping"} 0
 windows_service_status{name="fontcache",status="stressed"} 0
 windows_service_status{name="fontcache",status="unknown"} 0
+windows_service_status{name="fontcache3.0.0.0",status="degraded"} 0
+windows_service_status{name="fontcache3.0.0.0",status="error"} 0
+windows_service_status{name="fontcache3.0.0.0",status="lost comm"} 0
+windows_service_status{name="fontcache3.0.0.0",status="no contact"} 0
+windows_service_status{name="fontcache3.0.0.0",status="nonrecover"} 0
+windows_service_status{name="fontcache3.0.0.0",status="ok"} 1
+windows_service_status{name="fontcache3.0.0.0",status="pred fail"} 0
+windows_service_status{name="fontcache3.0.0.0",status="service"} 0
+windows_service_status{name="fontcache3.0.0.0",status="starting"} 0
+windows_service_status{name="fontcache3.0.0.0",status="stopping"} 0
+windows_service_status{name="fontcache3.0.0.0",status="stressed"} 0
+windows_service_status{name="fontcache3.0.0.0",status="unknown"} 0
 windows_service_status{name="frameserver",status="degraded"} 0
 windows_service_status{name="frameserver",status="error"} 0
 windows_service_status{name="frameserver",status="lost comm"} 0
@@ -3480,6 +4558,18 @@ windows_service_status{name="gpsvc",status="starting"} 0
 windows_service_status{name="gpsvc",status="stopping"} 0
 windows_service_status{name="gpsvc",status="stressed"} 0
 windows_service_status{name="gpsvc",status="unknown"} 0
+windows_service_status{name="graphicsperfsvc",status="degraded"} 0
+windows_service_status{name="graphicsperfsvc",status="error"} 0
+windows_service_status{name="graphicsperfsvc",status="lost comm"} 0
+windows_service_status{name="graphicsperfsvc",status="no contact"} 0
+windows_service_status{name="graphicsperfsvc",status="nonrecover"} 0
+windows_service_status{name="graphicsperfsvc",status="ok"} 1
+windows_service_status{name="graphicsperfsvc",status="pred fail"} 0
+windows_service_status{name="graphicsperfsvc",status="service"} 0
+windows_service_status{name="graphicsperfsvc",status="starting"} 0
+windows_service_status{name="graphicsperfsvc",status="stopping"} 0
+windows_service_status{name="graphicsperfsvc",status="stressed"} 0
+windows_service_status{name="graphicsperfsvc",status="unknown"} 0
 windows_service_status{name="hidserv",status="degraded"} 0
 windows_service_status{name="hidserv",status="error"} 0
 windows_service_status{name="hidserv",status="lost comm"} 0
@@ -3528,6 +4618,18 @@ windows_service_status{name="ikeext",status="starting"} 0
 windows_service_status{name="ikeext",status="stopping"} 0
 windows_service_status{name="ikeext",status="stressed"} 0
 windows_service_status{name="ikeext",status="unknown"} 0
+windows_service_status{name="installservice",status="degraded"} 0
+windows_service_status{name="installservice",status="error"} 0
+windows_service_status{name="installservice",status="lost comm"} 0
+windows_service_status{name="installservice",status="no contact"} 0
+windows_service_status{name="installservice",status="nonrecover"} 0
+windows_service_status{name="installservice",status="ok"} 1
+windows_service_status{name="installservice",status="pred fail"} 0
+windows_service_status{name="installservice",status="service"} 0
+windows_service_status{name="installservice",status="starting"} 0
+windows_service_status{name="installservice",status="stopping"} 0
+windows_service_status{name="installservice",status="stressed"} 0
+windows_service_status{name="installservice",status="unknown"} 0
 windows_service_status{name="iphlpsvc",status="degraded"} 0
 windows_service_status{name="iphlpsvc",status="error"} 0
 windows_service_status{name="iphlpsvc",status="lost comm"} 0
@@ -3540,6 +4642,30 @@ windows_service_status{name="iphlpsvc",status="starting"} 0
 windows_service_status{name="iphlpsvc",status="stopping"} 0
 windows_service_status{name="iphlpsvc",status="stressed"} 0
 windows_service_status{name="iphlpsvc",status="unknown"} 0
+windows_service_status{name="ipoverusbsvc",status="degraded"} 0
+windows_service_status{name="ipoverusbsvc",status="error"} 0
+windows_service_status{name="ipoverusbsvc",status="lost comm"} 0
+windows_service_status{name="ipoverusbsvc",status="no contact"} 0
+windows_service_status{name="ipoverusbsvc",status="nonrecover"} 0
+windows_service_status{name="ipoverusbsvc",status="ok"} 1
+windows_service_status{name="ipoverusbsvc",status="pred fail"} 0
+windows_service_status{name="ipoverusbsvc",status="service"} 0
+windows_service_status{name="ipoverusbsvc",status="starting"} 0
+windows_service_status{name="ipoverusbsvc",status="stopping"} 0
+windows_service_status{name="ipoverusbsvc",status="stressed"} 0
+windows_service_status{name="ipoverusbsvc",status="unknown"} 0
+windows_service_status{name="ipxlatcfgsvc",status="degraded"} 0
+windows_service_status{name="ipxlatcfgsvc",status="error"} 0
+windows_service_status{name="ipxlatcfgsvc",status="lost comm"} 0
+windows_service_status{name="ipxlatcfgsvc",status="no contact"} 0
+windows_service_status{name="ipxlatcfgsvc",status="nonrecover"} 0
+windows_service_status{name="ipxlatcfgsvc",status="ok"} 1
+windows_service_status{name="ipxlatcfgsvc",status="pred fail"} 0
+windows_service_status{name="ipxlatcfgsvc",status="service"} 0
+windows_service_status{name="ipxlatcfgsvc",status="starting"} 0
+windows_service_status{name="ipxlatcfgsvc",status="stopping"} 0
+windows_service_status{name="ipxlatcfgsvc",status="stressed"} 0
+windows_service_status{name="ipxlatcfgsvc",status="unknown"} 0
 windows_service_status{name="keyiso",status="degraded"} 0
 windows_service_status{name="keyiso",status="error"} 0
 windows_service_status{name="keyiso",status="lost comm"} 0
@@ -3552,18 +4678,6 @@ windows_service_status{name="keyiso",status="starting"} 0
 windows_service_status{name="keyiso",status="stopping"} 0
 windows_service_status{name="keyiso",status="stressed"} 0
 windows_service_status{name="keyiso",status="unknown"} 0
-windows_service_status{name="kpssvc",status="degraded"} 0
-windows_service_status{name="kpssvc",status="error"} 0
-windows_service_status{name="kpssvc",status="lost comm"} 0
-windows_service_status{name="kpssvc",status="no contact"} 0
-windows_service_status{name="kpssvc",status="nonrecover"} 0
-windows_service_status{name="kpssvc",status="ok"} 1
-windows_service_status{name="kpssvc",status="pred fail"} 0
-windows_service_status{name="kpssvc",status="service"} 0
-windows_service_status{name="kpssvc",status="starting"} 0
-windows_service_status{name="kpssvc",status="stopping"} 0
-windows_service_status{name="kpssvc",status="stressed"} 0
-windows_service_status{name="kpssvc",status="unknown"} 0
 windows_service_status{name="ktmrm",status="degraded"} 0
 windows_service_status{name="ktmrm",status="error"} 0
 windows_service_status{name="ktmrm",status="lost comm"} 0
@@ -3653,13 +4767,25 @@ windows_service_status{name="lsm",status="error"} 0
 windows_service_status{name="lsm",status="lost comm"} 0
 windows_service_status{name="lsm",status="no contact"} 0
 windows_service_status{name="lsm",status="nonrecover"} 0
-windows_service_status{name="lsm",status="ok"} 1
+windows_service_status{name="lsm",status="ok"} 0
 windows_service_status{name="lsm",status="pred fail"} 0
 windows_service_status{name="lsm",status="service"} 0
 windows_service_status{name="lsm",status="starting"} 0
 windows_service_status{name="lsm",status="stopping"} 0
 windows_service_status{name="lsm",status="stressed"} 0
-windows_service_status{name="lsm",status="unknown"} 0
+windows_service_status{name="lsm",status="unknown"} 1
+windows_service_status{name="lxpsvc",status="degraded"} 0
+windows_service_status{name="lxpsvc",status="error"} 0
+windows_service_status{name="lxpsvc",status="lost comm"} 0
+windows_service_status{name="lxpsvc",status="no contact"} 0
+windows_service_status{name="lxpsvc",status="nonrecover"} 0
+windows_service_status{name="lxpsvc",status="ok"} 1
+windows_service_status{name="lxpsvc",status="pred fail"} 0
+windows_service_status{name="lxpsvc",status="service"} 0
+windows_service_status{name="lxpsvc",status="starting"} 0
+windows_service_status{name="lxpsvc",status="stopping"} 0
+windows_service_status{name="lxpsvc",status="stressed"} 0
+windows_service_status{name="lxpsvc",status="unknown"} 0
 windows_service_status{name="mapsbroker",status="degraded"} 0
 windows_service_status{name="mapsbroker",status="error"} 0
 windows_service_status{name="mapsbroker",status="lost comm"} 0
@@ -3672,6 +4798,42 @@ windows_service_status{name="mapsbroker",status="starting"} 0
 windows_service_status{name="mapsbroker",status="stopping"} 0
 windows_service_status{name="mapsbroker",status="stressed"} 0
 windows_service_status{name="mapsbroker",status="unknown"} 0
+windows_service_status{name="messagingservice_390e7",status="degraded"} 0
+windows_service_status{name="messagingservice_390e7",status="error"} 0
+windows_service_status{name="messagingservice_390e7",status="lost comm"} 0
+windows_service_status{name="messagingservice_390e7",status="no contact"} 0
+windows_service_status{name="messagingservice_390e7",status="nonrecover"} 0
+windows_service_status{name="messagingservice_390e7",status="ok"} 1
+windows_service_status{name="messagingservice_390e7",status="pred fail"} 0
+windows_service_status{name="messagingservice_390e7",status="service"} 0
+windows_service_status{name="messagingservice_390e7",status="starting"} 0
+windows_service_status{name="messagingservice_390e7",status="stopping"} 0
+windows_service_status{name="messagingservice_390e7",status="stressed"} 0
+windows_service_status{name="messagingservice_390e7",status="unknown"} 0
+windows_service_status{name="mixedrealityopenxrsvc",status="degraded"} 0
+windows_service_status{name="mixedrealityopenxrsvc",status="error"} 0
+windows_service_status{name="mixedrealityopenxrsvc",status="lost comm"} 0
+windows_service_status{name="mixedrealityopenxrsvc",status="no contact"} 0
+windows_service_status{name="mixedrealityopenxrsvc",status="nonrecover"} 0
+windows_service_status{name="mixedrealityopenxrsvc",status="ok"} 1
+windows_service_status{name="mixedrealityopenxrsvc",status="pred fail"} 0
+windows_service_status{name="mixedrealityopenxrsvc",status="service"} 0
+windows_service_status{name="mixedrealityopenxrsvc",status="starting"} 0
+windows_service_status{name="mixedrealityopenxrsvc",status="stopping"} 0
+windows_service_status{name="mixedrealityopenxrsvc",status="stressed"} 0
+windows_service_status{name="mixedrealityopenxrsvc",status="unknown"} 0
+windows_service_status{name="mozillamaintenance",status="degraded"} 0
+windows_service_status{name="mozillamaintenance",status="error"} 0
+windows_service_status{name="mozillamaintenance",status="lost comm"} 0
+windows_service_status{name="mozillamaintenance",status="no contact"} 0
+windows_service_status{name="mozillamaintenance",status="nonrecover"} 0
+windows_service_status{name="mozillamaintenance",status="ok"} 1
+windows_service_status{name="mozillamaintenance",status="pred fail"} 0
+windows_service_status{name="mozillamaintenance",status="service"} 0
+windows_service_status{name="mozillamaintenance",status="starting"} 0
+windows_service_status{name="mozillamaintenance",status="stopping"} 0
+windows_service_status{name="mozillamaintenance",status="stressed"} 0
+windows_service_status{name="mozillamaintenance",status="unknown"} 0
 windows_service_status{name="mpssvc",status="degraded"} 0
 windows_service_status{name="mpssvc",status="error"} 0
 windows_service_status{name="mpssvc",status="lost comm"} 0
@@ -3720,6 +4882,18 @@ windows_service_status{name="msiserver",status="starting"} 0
 windows_service_status{name="msiserver",status="stopping"} 0
 windows_service_status{name="msiserver",status="stressed"} 0
 windows_service_status{name="msiserver",status="unknown"} 0
+windows_service_status{name="naturalauthentication",status="degraded"} 0
+windows_service_status{name="naturalauthentication",status="error"} 0
+windows_service_status{name="naturalauthentication",status="lost comm"} 0
+windows_service_status{name="naturalauthentication",status="no contact"} 0
+windows_service_status{name="naturalauthentication",status="nonrecover"} 0
+windows_service_status{name="naturalauthentication",status="ok"} 1
+windows_service_status{name="naturalauthentication",status="pred fail"} 0
+windows_service_status{name="naturalauthentication",status="service"} 0
+windows_service_status{name="naturalauthentication",status="starting"} 0
+windows_service_status{name="naturalauthentication",status="stopping"} 0
+windows_service_status{name="naturalauthentication",status="stressed"} 0
+windows_service_status{name="naturalauthentication",status="unknown"} 0
 windows_service_status{name="ncasvc",status="degraded"} 0
 windows_service_status{name="ncasvc",status="error"} 0
 windows_service_status{name="ncasvc",status="lost comm"} 0
@@ -3744,6 +4918,18 @@ windows_service_status{name="ncbservice",status="starting"} 0
 windows_service_status{name="ncbservice",status="stopping"} 0
 windows_service_status{name="ncbservice",status="stressed"} 0
 windows_service_status{name="ncbservice",status="unknown"} 0
+windows_service_status{name="ncdautosetup",status="degraded"} 0
+windows_service_status{name="ncdautosetup",status="error"} 0
+windows_service_status{name="ncdautosetup",status="lost comm"} 0
+windows_service_status{name="ncdautosetup",status="no contact"} 0
+windows_service_status{name="ncdautosetup",status="nonrecover"} 0
+windows_service_status{name="ncdautosetup",status="ok"} 1
+windows_service_status{name="ncdautosetup",status="pred fail"} 0
+windows_service_status{name="ncdautosetup",status="service"} 0
+windows_service_status{name="ncdautosetup",status="starting"} 0
+windows_service_status{name="ncdautosetup",status="stopping"} 0
+windows_service_status{name="ncdautosetup",status="stressed"} 0
+windows_service_status{name="ncdautosetup",status="unknown"} 0
 windows_service_status{name="netlogon",status="degraded"} 0
 windows_service_status{name="netlogon",status="error"} 0
 windows_service_status{name="netlogon",status="lost comm"} 0
@@ -3785,13 +4971,13 @@ windows_service_status{name="netsetupsvc",status="error"} 0
 windows_service_status{name="netsetupsvc",status="lost comm"} 0
 windows_service_status{name="netsetupsvc",status="no contact"} 0
 windows_service_status{name="netsetupsvc",status="nonrecover"} 0
-windows_service_status{name="netsetupsvc",status="ok"} 1
+windows_service_status{name="netsetupsvc",status="ok"} 0
 windows_service_status{name="netsetupsvc",status="pred fail"} 0
 windows_service_status{name="netsetupsvc",status="service"} 0
 windows_service_status{name="netsetupsvc",status="starting"} 0
 windows_service_status{name="netsetupsvc",status="stopping"} 0
 windows_service_status{name="netsetupsvc",status="stressed"} 0
-windows_service_status{name="netsetupsvc",status="unknown"} 0
+windows_service_status{name="netsetupsvc",status="unknown"} 1
 windows_service_status{name="nettcpportsharing",status="degraded"} 0
 windows_service_status{name="nettcpportsharing",status="error"} 0
 windows_service_status{name="nettcpportsharing",status="lost comm"} 0
@@ -3864,18 +5050,42 @@ windows_service_status{name="nsi",status="starting"} 0
 windows_service_status{name="nsi",status="stopping"} 0
 windows_service_status{name="nsi",status="stressed"} 0
 windows_service_status{name="nsi",status="unknown"} 0
-windows_service_status{name="onesyncsvc_225e3",status="degraded"} 0
-windows_service_status{name="onesyncsvc_225e3",status="error"} 0
-windows_service_status{name="onesyncsvc_225e3",status="lost comm"} 0
-windows_service_status{name="onesyncsvc_225e3",status="no contact"} 0
-windows_service_status{name="onesyncsvc_225e3",status="nonrecover"} 0
-windows_service_status{name="onesyncsvc_225e3",status="ok"} 1
-windows_service_status{name="onesyncsvc_225e3",status="pred fail"} 0
-windows_service_status{name="onesyncsvc_225e3",status="service"} 0
-windows_service_status{name="onesyncsvc_225e3",status="starting"} 0
-windows_service_status{name="onesyncsvc_225e3",status="stopping"} 0
-windows_service_status{name="onesyncsvc_225e3",status="stressed"} 0
-windows_service_status{name="onesyncsvc_225e3",status="unknown"} 0
+windows_service_status{name="onesyncsvc_390e7",status="degraded"} 0
+windows_service_status{name="onesyncsvc_390e7",status="error"} 0
+windows_service_status{name="onesyncsvc_390e7",status="lost comm"} 0
+windows_service_status{name="onesyncsvc_390e7",status="no contact"} 0
+windows_service_status{name="onesyncsvc_390e7",status="nonrecover"} 0
+windows_service_status{name="onesyncsvc_390e7",status="ok"} 1
+windows_service_status{name="onesyncsvc_390e7",status="pred fail"} 0
+windows_service_status{name="onesyncsvc_390e7",status="service"} 0
+windows_service_status{name="onesyncsvc_390e7",status="starting"} 0
+windows_service_status{name="onesyncsvc_390e7",status="stopping"} 0
+windows_service_status{name="onesyncsvc_390e7",status="stressed"} 0
+windows_service_status{name="onesyncsvc_390e7",status="unknown"} 0
+windows_service_status{name="p2pimsvc",status="degraded"} 0
+windows_service_status{name="p2pimsvc",status="error"} 0
+windows_service_status{name="p2pimsvc",status="lost comm"} 0
+windows_service_status{name="p2pimsvc",status="no contact"} 0
+windows_service_status{name="p2pimsvc",status="nonrecover"} 0
+windows_service_status{name="p2pimsvc",status="ok"} 1
+windows_service_status{name="p2pimsvc",status="pred fail"} 0
+windows_service_status{name="p2pimsvc",status="service"} 0
+windows_service_status{name="p2pimsvc",status="starting"} 0
+windows_service_status{name="p2pimsvc",status="stopping"} 0
+windows_service_status{name="p2pimsvc",status="stressed"} 0
+windows_service_status{name="p2pimsvc",status="unknown"} 0
+windows_service_status{name="p2psvc",status="degraded"} 0
+windows_service_status{name="p2psvc",status="error"} 0
+windows_service_status{name="p2psvc",status="lost comm"} 0
+windows_service_status{name="p2psvc",status="no contact"} 0
+windows_service_status{name="p2psvc",status="nonrecover"} 0
+windows_service_status{name="p2psvc",status="ok"} 1
+windows_service_status{name="p2psvc",status="pred fail"} 0
+windows_service_status{name="p2psvc",status="service"} 0
+windows_service_status{name="p2psvc",status="starting"} 0
+windows_service_status{name="p2psvc",status="stopping"} 0
+windows_service_status{name="p2psvc",status="stressed"} 0
+windows_service_status{name="p2psvc",status="unknown"} 0
 windows_service_status{name="pcasvc",status="degraded"} 0
 windows_service_status{name="pcasvc",status="error"} 0
 windows_service_status{name="pcasvc",status="lost comm"} 0
@@ -3888,6 +5098,30 @@ windows_service_status{name="pcasvc",status="starting"} 0
 windows_service_status{name="pcasvc",status="stopping"} 0
 windows_service_status{name="pcasvc",status="stressed"} 0
 windows_service_status{name="pcasvc",status="unknown"} 0
+windows_service_status{name="peerdistsvc",status="degraded"} 0
+windows_service_status{name="peerdistsvc",status="error"} 0
+windows_service_status{name="peerdistsvc",status="lost comm"} 0
+windows_service_status{name="peerdistsvc",status="no contact"} 0
+windows_service_status{name="peerdistsvc",status="nonrecover"} 0
+windows_service_status{name="peerdistsvc",status="ok"} 1
+windows_service_status{name="peerdistsvc",status="pred fail"} 0
+windows_service_status{name="peerdistsvc",status="service"} 0
+windows_service_status{name="peerdistsvc",status="starting"} 0
+windows_service_status{name="peerdistsvc",status="stopping"} 0
+windows_service_status{name="peerdistsvc",status="stressed"} 0
+windows_service_status{name="peerdistsvc",status="unknown"} 0
+windows_service_status{name="perceptionsimulation",status="degraded"} 0
+windows_service_status{name="perceptionsimulation",status="error"} 0
+windows_service_status{name="perceptionsimulation",status="lost comm"} 0
+windows_service_status{name="perceptionsimulation",status="no contact"} 0
+windows_service_status{name="perceptionsimulation",status="nonrecover"} 0
+windows_service_status{name="perceptionsimulation",status="ok"} 1
+windows_service_status{name="perceptionsimulation",status="pred fail"} 0
+windows_service_status{name="perceptionsimulation",status="service"} 0
+windows_service_status{name="perceptionsimulation",status="starting"} 0
+windows_service_status{name="perceptionsimulation",status="stopping"} 0
+windows_service_status{name="perceptionsimulation",status="stressed"} 0
+windows_service_status{name="perceptionsimulation",status="unknown"} 0
 windows_service_status{name="perfhost",status="degraded"} 0
 windows_service_status{name="perfhost",status="error"} 0
 windows_service_status{name="perfhost",status="lost comm"} 0
@@ -3912,18 +5146,18 @@ windows_service_status{name="phonesvc",status="starting"} 0
 windows_service_status{name="phonesvc",status="stopping"} 0
 windows_service_status{name="phonesvc",status="stressed"} 0
 windows_service_status{name="phonesvc",status="unknown"} 0
-windows_service_status{name="pimindexmaintenancesvc_225e3",status="degraded"} 0
-windows_service_status{name="pimindexmaintenancesvc_225e3",status="error"} 0
-windows_service_status{name="pimindexmaintenancesvc_225e3",status="lost comm"} 0
-windows_service_status{name="pimindexmaintenancesvc_225e3",status="no contact"} 0
-windows_service_status{name="pimindexmaintenancesvc_225e3",status="nonrecover"} 0
-windows_service_status{name="pimindexmaintenancesvc_225e3",status="ok"} 1
-windows_service_status{name="pimindexmaintenancesvc_225e3",status="pred fail"} 0
-windows_service_status{name="pimindexmaintenancesvc_225e3",status="service"} 0
-windows_service_status{name="pimindexmaintenancesvc_225e3",status="starting"} 0
-windows_service_status{name="pimindexmaintenancesvc_225e3",status="stopping"} 0
-windows_service_status{name="pimindexmaintenancesvc_225e3",status="stressed"} 0
-windows_service_status{name="pimindexmaintenancesvc_225e3",status="unknown"} 0
+windows_service_status{name="pimindexmaintenancesvc_390e7",status="degraded"} 0
+windows_service_status{name="pimindexmaintenancesvc_390e7",status="error"} 0
+windows_service_status{name="pimindexmaintenancesvc_390e7",status="lost comm"} 0
+windows_service_status{name="pimindexmaintenancesvc_390e7",status="no contact"} 0
+windows_service_status{name="pimindexmaintenancesvc_390e7",status="nonrecover"} 0
+windows_service_status{name="pimindexmaintenancesvc_390e7",status="ok"} 1
+windows_service_status{name="pimindexmaintenancesvc_390e7",status="pred fail"} 0
+windows_service_status{name="pimindexmaintenancesvc_390e7",status="service"} 0
+windows_service_status{name="pimindexmaintenancesvc_390e7",status="starting"} 0
+windows_service_status{name="pimindexmaintenancesvc_390e7",status="stopping"} 0
+windows_service_status{name="pimindexmaintenancesvc_390e7",status="stressed"} 0
+windows_service_status{name="pimindexmaintenancesvc_390e7",status="unknown"} 0
 windows_service_status{name="pla",status="degraded"} 0
 windows_service_status{name="pla",status="error"} 0
 windows_service_status{name="pla",status="lost comm"} 0
@@ -3948,6 +5182,30 @@ windows_service_status{name="plugplay",status="starting"} 0
 windows_service_status{name="plugplay",status="stopping"} 0
 windows_service_status{name="plugplay",status="stressed"} 0
 windows_service_status{name="plugplay",status="unknown"} 0
+windows_service_status{name="pnrpautoreg",status="degraded"} 0
+windows_service_status{name="pnrpautoreg",status="error"} 0
+windows_service_status{name="pnrpautoreg",status="lost comm"} 0
+windows_service_status{name="pnrpautoreg",status="no contact"} 0
+windows_service_status{name="pnrpautoreg",status="nonrecover"} 0
+windows_service_status{name="pnrpautoreg",status="ok"} 1
+windows_service_status{name="pnrpautoreg",status="pred fail"} 0
+windows_service_status{name="pnrpautoreg",status="service"} 0
+windows_service_status{name="pnrpautoreg",status="starting"} 0
+windows_service_status{name="pnrpautoreg",status="stopping"} 0
+windows_service_status{name="pnrpautoreg",status="stressed"} 0
+windows_service_status{name="pnrpautoreg",status="unknown"} 0
+windows_service_status{name="pnrpsvc",status="degraded"} 0
+windows_service_status{name="pnrpsvc",status="error"} 0
+windows_service_status{name="pnrpsvc",status="lost comm"} 0
+windows_service_status{name="pnrpsvc",status="no contact"} 0
+windows_service_status{name="pnrpsvc",status="nonrecover"} 0
+windows_service_status{name="pnrpsvc",status="ok"} 1
+windows_service_status{name="pnrpsvc",status="pred fail"} 0
+windows_service_status{name="pnrpsvc",status="service"} 0
+windows_service_status{name="pnrpsvc",status="starting"} 0
+windows_service_status{name="pnrpsvc",status="stopping"} 0
+windows_service_status{name="pnrpsvc",status="stressed"} 0
+windows_service_status{name="pnrpsvc",status="unknown"} 0
 windows_service_status{name="policyagent",status="degraded"} 0
 windows_service_status{name="policyagent",status="error"} 0
 windows_service_status{name="policyagent",status="lost comm"} 0
@@ -3984,6 +5242,18 @@ windows_service_status{name="printnotify",status="starting"} 0
 windows_service_status{name="printnotify",status="stopping"} 0
 windows_service_status{name="printnotify",status="stressed"} 0
 windows_service_status{name="printnotify",status="unknown"} 0
+windows_service_status{name="printworkflowusersvc_390e7",status="degraded"} 0
+windows_service_status{name="printworkflowusersvc_390e7",status="error"} 0
+windows_service_status{name="printworkflowusersvc_390e7",status="lost comm"} 0
+windows_service_status{name="printworkflowusersvc_390e7",status="no contact"} 0
+windows_service_status{name="printworkflowusersvc_390e7",status="nonrecover"} 0
+windows_service_status{name="printworkflowusersvc_390e7",status="ok"} 1
+windows_service_status{name="printworkflowusersvc_390e7",status="pred fail"} 0
+windows_service_status{name="printworkflowusersvc_390e7",status="service"} 0
+windows_service_status{name="printworkflowusersvc_390e7",status="starting"} 0
+windows_service_status{name="printworkflowusersvc_390e7",status="stopping"} 0
+windows_service_status{name="printworkflowusersvc_390e7",status="stressed"} 0
+windows_service_status{name="printworkflowusersvc_390e7",status="unknown"} 0
 windows_service_status{name="profsvc",status="degraded"} 0
 windows_service_status{name="profsvc",status="error"} 0
 windows_service_status{name="profsvc",status="lost comm"} 0
@@ -3996,6 +5266,18 @@ windows_service_status{name="profsvc",status="starting"} 0
 windows_service_status{name="profsvc",status="stopping"} 0
 windows_service_status{name="profsvc",status="stressed"} 0
 windows_service_status{name="profsvc",status="unknown"} 0
+windows_service_status{name="pushtoinstall",status="degraded"} 0
+windows_service_status{name="pushtoinstall",status="error"} 0
+windows_service_status{name="pushtoinstall",status="lost comm"} 0
+windows_service_status{name="pushtoinstall",status="no contact"} 0
+windows_service_status{name="pushtoinstall",status="nonrecover"} 0
+windows_service_status{name="pushtoinstall",status="ok"} 1
+windows_service_status{name="pushtoinstall",status="pred fail"} 0
+windows_service_status{name="pushtoinstall",status="service"} 0
+windows_service_status{name="pushtoinstall",status="starting"} 0
+windows_service_status{name="pushtoinstall",status="stopping"} 0
+windows_service_status{name="pushtoinstall",status="stressed"} 0
+windows_service_status{name="pushtoinstall",status="unknown"} 0
 windows_service_status{name="qwave",status="degraded"} 0
 windows_service_status{name="qwave",status="error"} 0
 windows_service_status{name="qwave",status="lost comm"} 0
@@ -4056,6 +5338,18 @@ windows_service_status{name="remoteregistry",status="starting"} 0
 windows_service_status{name="remoteregistry",status="stopping"} 0
 windows_service_status{name="remoteregistry",status="stressed"} 0
 windows_service_status{name="remoteregistry",status="unknown"} 0
+windows_service_status{name="retaildemo",status="degraded"} 0
+windows_service_status{name="retaildemo",status="error"} 0
+windows_service_status{name="retaildemo",status="lost comm"} 0
+windows_service_status{name="retaildemo",status="no contact"} 0
+windows_service_status{name="retaildemo",status="nonrecover"} 0
+windows_service_status{name="retaildemo",status="ok"} 1
+windows_service_status{name="retaildemo",status="pred fail"} 0
+windows_service_status{name="retaildemo",status="service"} 0
+windows_service_status{name="retaildemo",status="starting"} 0
+windows_service_status{name="retaildemo",status="stopping"} 0
+windows_service_status{name="retaildemo",status="stressed"} 0
+windows_service_status{name="retaildemo",status="unknown"} 0
 windows_service_status{name="rmsvc",status="degraded"} 0
 windows_service_status{name="rmsvc",status="error"} 0
 windows_service_status{name="rmsvc",status="lost comm"} 0
@@ -4104,30 +5398,6 @@ windows_service_status{name="rpcss",status="starting"} 0
 windows_service_status{name="rpcss",status="stopping"} 0
 windows_service_status{name="rpcss",status="stressed"} 0
 windows_service_status{name="rpcss",status="unknown"} 0
-windows_service_status{name="rsopprov",status="degraded"} 0
-windows_service_status{name="rsopprov",status="error"} 0
-windows_service_status{name="rsopprov",status="lost comm"} 0
-windows_service_status{name="rsopprov",status="no contact"} 0
-windows_service_status{name="rsopprov",status="nonrecover"} 0
-windows_service_status{name="rsopprov",status="ok"} 1
-windows_service_status{name="rsopprov",status="pred fail"} 0
-windows_service_status{name="rsopprov",status="service"} 0
-windows_service_status{name="rsopprov",status="starting"} 0
-windows_service_status{name="rsopprov",status="stopping"} 0
-windows_service_status{name="rsopprov",status="stressed"} 0
-windows_service_status{name="rsopprov",status="unknown"} 0
-windows_service_status{name="sacsvr",status="degraded"} 0
-windows_service_status{name="sacsvr",status="error"} 0
-windows_service_status{name="sacsvr",status="lost comm"} 0
-windows_service_status{name="sacsvr",status="no contact"} 0
-windows_service_status{name="sacsvr",status="nonrecover"} 0
-windows_service_status{name="sacsvr",status="ok"} 1
-windows_service_status{name="sacsvr",status="pred fail"} 0
-windows_service_status{name="sacsvr",status="service"} 0
-windows_service_status{name="sacsvr",status="starting"} 0
-windows_service_status{name="sacsvr",status="stopping"} 0
-windows_service_status{name="sacsvr",status="stressed"} 0
-windows_service_status{name="sacsvr",status="unknown"} 0
 windows_service_status{name="samss",status="degraded"} 0
 windows_service_status{name="samss",status="error"} 0
 windows_service_status{name="samss",status="lost comm"} 0
@@ -4188,6 +5458,18 @@ windows_service_status{name="scpolicysvc",status="starting"} 0
 windows_service_status{name="scpolicysvc",status="stopping"} 0
 windows_service_status{name="scpolicysvc",status="stressed"} 0
 windows_service_status{name="scpolicysvc",status="unknown"} 0
+windows_service_status{name="sdrsvc",status="degraded"} 0
+windows_service_status{name="sdrsvc",status="error"} 0
+windows_service_status{name="sdrsvc",status="lost comm"} 0
+windows_service_status{name="sdrsvc",status="no contact"} 0
+windows_service_status{name="sdrsvc",status="nonrecover"} 0
+windows_service_status{name="sdrsvc",status="ok"} 1
+windows_service_status{name="sdrsvc",status="pred fail"} 0
+windows_service_status{name="sdrsvc",status="service"} 0
+windows_service_status{name="sdrsvc",status="starting"} 0
+windows_service_status{name="sdrsvc",status="stopping"} 0
+windows_service_status{name="sdrsvc",status="stressed"} 0
+windows_service_status{name="sdrsvc",status="unknown"} 0
 windows_service_status{name="seclogon",status="degraded"} 0
 windows_service_status{name="seclogon",status="error"} 0
 windows_service_status{name="seclogon",status="lost comm"} 0
@@ -4200,6 +5482,30 @@ windows_service_status{name="seclogon",status="starting"} 0
 windows_service_status{name="seclogon",status="stopping"} 0
 windows_service_status{name="seclogon",status="stressed"} 0
 windows_service_status{name="seclogon",status="unknown"} 0
+windows_service_status{name="securityhealthservice",status="degraded"} 0
+windows_service_status{name="securityhealthservice",status="error"} 0
+windows_service_status{name="securityhealthservice",status="lost comm"} 0
+windows_service_status{name="securityhealthservice",status="no contact"} 0
+windows_service_status{name="securityhealthservice",status="nonrecover"} 0
+windows_service_status{name="securityhealthservice",status="ok"} 1
+windows_service_status{name="securityhealthservice",status="pred fail"} 0
+windows_service_status{name="securityhealthservice",status="service"} 0
+windows_service_status{name="securityhealthservice",status="starting"} 0
+windows_service_status{name="securityhealthservice",status="stopping"} 0
+windows_service_status{name="securityhealthservice",status="stressed"} 0
+windows_service_status{name="securityhealthservice",status="unknown"} 0
+windows_service_status{name="semgrsvc",status="degraded"} 0
+windows_service_status{name="semgrsvc",status="error"} 0
+windows_service_status{name="semgrsvc",status="lost comm"} 0
+windows_service_status{name="semgrsvc",status="no contact"} 0
+windows_service_status{name="semgrsvc",status="nonrecover"} 0
+windows_service_status{name="semgrsvc",status="ok"} 1
+windows_service_status{name="semgrsvc",status="pred fail"} 0
+windows_service_status{name="semgrsvc",status="service"} 0
+windows_service_status{name="semgrsvc",status="starting"} 0
+windows_service_status{name="semgrsvc",status="stopping"} 0
+windows_service_status{name="semgrsvc",status="stressed"} 0
+windows_service_status{name="semgrsvc",status="unknown"} 0
 windows_service_status{name="sens",status="degraded"} 0
 windows_service_status{name="sens",status="error"} 0
 windows_service_status{name="sens",status="lost comm"} 0
@@ -4212,6 +5518,18 @@ windows_service_status{name="sens",status="starting"} 0
 windows_service_status{name="sens",status="stopping"} 0
 windows_service_status{name="sens",status="stressed"} 0
 windows_service_status{name="sens",status="unknown"} 0
+windows_service_status{name="sense",status="degraded"} 0
+windows_service_status{name="sense",status="error"} 0
+windows_service_status{name="sense",status="lost comm"} 0
+windows_service_status{name="sense",status="no contact"} 0
+windows_service_status{name="sense",status="nonrecover"} 0
+windows_service_status{name="sense",status="ok"} 1
+windows_service_status{name="sense",status="pred fail"} 0
+windows_service_status{name="sense",status="service"} 0
+windows_service_status{name="sense",status="starting"} 0
+windows_service_status{name="sense",status="stopping"} 0
+windows_service_status{name="sense",status="stressed"} 0
+windows_service_status{name="sense",status="unknown"} 0
 windows_service_status{name="sensordataservice",status="degraded"} 0
 windows_service_status{name="sensordataservice",status="error"} 0
 windows_service_status{name="sensordataservice",status="lost comm"} 0
@@ -4260,6 +5578,18 @@ windows_service_status{name="sessionenv",status="starting"} 0
 windows_service_status{name="sessionenv",status="stopping"} 0
 windows_service_status{name="sessionenv",status="stressed"} 0
 windows_service_status{name="sessionenv",status="unknown"} 0
+windows_service_status{name="sgrmbroker",status="degraded"} 0
+windows_service_status{name="sgrmbroker",status="error"} 0
+windows_service_status{name="sgrmbroker",status="lost comm"} 0
+windows_service_status{name="sgrmbroker",status="no contact"} 0
+windows_service_status{name="sgrmbroker",status="nonrecover"} 0
+windows_service_status{name="sgrmbroker",status="ok"} 1
+windows_service_status{name="sgrmbroker",status="pred fail"} 0
+windows_service_status{name="sgrmbroker",status="service"} 0
+windows_service_status{name="sgrmbroker",status="starting"} 0
+windows_service_status{name="sgrmbroker",status="stopping"} 0
+windows_service_status{name="sgrmbroker",status="stressed"} 0
+windows_service_status{name="sgrmbroker",status="unknown"} 0
 windows_service_status{name="sharedaccess",status="degraded"} 0
 windows_service_status{name="sharedaccess",status="error"} 0
 windows_service_status{name="sharedaccess",status="lost comm"} 0
@@ -4272,6 +5602,18 @@ windows_service_status{name="sharedaccess",status="starting"} 0
 windows_service_status{name="sharedaccess",status="stopping"} 0
 windows_service_status{name="sharedaccess",status="stressed"} 0
 windows_service_status{name="sharedaccess",status="unknown"} 0
+windows_service_status{name="sharedrealitysvc",status="degraded"} 0
+windows_service_status{name="sharedrealitysvc",status="error"} 0
+windows_service_status{name="sharedrealitysvc",status="lost comm"} 0
+windows_service_status{name="sharedrealitysvc",status="no contact"} 0
+windows_service_status{name="sharedrealitysvc",status="nonrecover"} 0
+windows_service_status{name="sharedrealitysvc",status="ok"} 1
+windows_service_status{name="sharedrealitysvc",status="pred fail"} 0
+windows_service_status{name="sharedrealitysvc",status="service"} 0
+windows_service_status{name="sharedrealitysvc",status="starting"} 0
+windows_service_status{name="sharedrealitysvc",status="stopping"} 0
+windows_service_status{name="sharedrealitysvc",status="stressed"} 0
+windows_service_status{name="sharedrealitysvc",status="unknown"} 0
 windows_service_status{name="shellhwdetection",status="degraded"} 0
 windows_service_status{name="shellhwdetection",status="error"} 0
 windows_service_status{name="shellhwdetection",status="lost comm"} 0
@@ -4284,6 +5626,18 @@ windows_service_status{name="shellhwdetection",status="starting"} 0
 windows_service_status{name="shellhwdetection",status="stopping"} 0
 windows_service_status{name="shellhwdetection",status="stressed"} 0
 windows_service_status{name="shellhwdetection",status="unknown"} 0
+windows_service_status{name="shpamsvc",status="degraded"} 0
+windows_service_status{name="shpamsvc",status="error"} 0
+windows_service_status{name="shpamsvc",status="lost comm"} 0
+windows_service_status{name="shpamsvc",status="no contact"} 0
+windows_service_status{name="shpamsvc",status="nonrecover"} 0
+windows_service_status{name="shpamsvc",status="ok"} 1
+windows_service_status{name="shpamsvc",status="pred fail"} 0
+windows_service_status{name="shpamsvc",status="service"} 0
+windows_service_status{name="shpamsvc",status="starting"} 0
+windows_service_status{name="shpamsvc",status="stopping"} 0
+windows_service_status{name="shpamsvc",status="stressed"} 0
+windows_service_status{name="shpamsvc",status="unknown"} 0
 windows_service_status{name="smphost",status="degraded"} 0
 windows_service_status{name="smphost",status="error"} 0
 windows_service_status{name="smphost",status="lost comm"} 0
@@ -4296,6 +5650,18 @@ windows_service_status{name="smphost",status="starting"} 0
 windows_service_status{name="smphost",status="stopping"} 0
 windows_service_status{name="smphost",status="stressed"} 0
 windows_service_status{name="smphost",status="unknown"} 0
+windows_service_status{name="smsrouter",status="degraded"} 0
+windows_service_status{name="smsrouter",status="error"} 0
+windows_service_status{name="smsrouter",status="lost comm"} 0
+windows_service_status{name="smsrouter",status="no contact"} 0
+windows_service_status{name="smsrouter",status="nonrecover"} 0
+windows_service_status{name="smsrouter",status="ok"} 1
+windows_service_status{name="smsrouter",status="pred fail"} 0
+windows_service_status{name="smsrouter",status="service"} 0
+windows_service_status{name="smsrouter",status="starting"} 0
+windows_service_status{name="smsrouter",status="stopping"} 0
+windows_service_status{name="smsrouter",status="stressed"} 0
+windows_service_status{name="smsrouter",status="unknown"} 0
 windows_service_status{name="snmptrap",status="degraded"} 0
 windows_service_status{name="snmptrap",status="error"} 0
 windows_service_status{name="snmptrap",status="lost comm"} 0
@@ -4308,6 +5674,18 @@ windows_service_status{name="snmptrap",status="starting"} 0
 windows_service_status{name="snmptrap",status="stopping"} 0
 windows_service_status{name="snmptrap",status="stressed"} 0
 windows_service_status{name="snmptrap",status="unknown"} 0
+windows_service_status{name="spectrum",status="degraded"} 0
+windows_service_status{name="spectrum",status="error"} 0
+windows_service_status{name="spectrum",status="lost comm"} 0
+windows_service_status{name="spectrum",status="no contact"} 0
+windows_service_status{name="spectrum",status="nonrecover"} 0
+windows_service_status{name="spectrum",status="ok"} 1
+windows_service_status{name="spectrum",status="pred fail"} 0
+windows_service_status{name="spectrum",status="service"} 0
+windows_service_status{name="spectrum",status="starting"} 0
+windows_service_status{name="spectrum",status="stopping"} 0
+windows_service_status{name="spectrum",status="stressed"} 0
+windows_service_status{name="spectrum",status="unknown"} 0
 windows_service_status{name="spooler",status="degraded"} 0
 windows_service_status{name="spooler",status="error"} 0
 windows_service_status{name="spooler",status="lost comm"} 0
@@ -4344,6 +5722,18 @@ windows_service_status{name="ssdpsrv",status="starting"} 0
 windows_service_status{name="ssdpsrv",status="stopping"} 0
 windows_service_status{name="ssdpsrv",status="stressed"} 0
 windows_service_status{name="ssdpsrv",status="unknown"} 0
+windows_service_status{name="ssh-agent",status="degraded"} 0
+windows_service_status{name="ssh-agent",status="error"} 0
+windows_service_status{name="ssh-agent",status="lost comm"} 0
+windows_service_status{name="ssh-agent",status="no contact"} 0
+windows_service_status{name="ssh-agent",status="nonrecover"} 0
+windows_service_status{name="ssh-agent",status="ok"} 1
+windows_service_status{name="ssh-agent",status="pred fail"} 0
+windows_service_status{name="ssh-agent",status="service"} 0
+windows_service_status{name="ssh-agent",status="starting"} 0
+windows_service_status{name="ssh-agent",status="stopping"} 0
+windows_service_status{name="ssh-agent",status="stressed"} 0
+windows_service_status{name="ssh-agent",status="unknown"} 0
 windows_service_status{name="sstpsvc",status="degraded"} 0
 windows_service_status{name="sstpsvc",status="error"} 0
 windows_service_status{name="sstpsvc",status="lost comm"} 0
@@ -4464,6 +5854,18 @@ windows_service_status{name="tapisrv",status="starting"} 0
 windows_service_status{name="tapisrv",status="stopping"} 0
 windows_service_status{name="tapisrv",status="stressed"} 0
 windows_service_status{name="tapisrv",status="unknown"} 0
+windows_service_status{name="te.service",status="degraded"} 0
+windows_service_status{name="te.service",status="error"} 0
+windows_service_status{name="te.service",status="lost comm"} 0
+windows_service_status{name="te.service",status="no contact"} 0
+windows_service_status{name="te.service",status="nonrecover"} 0
+windows_service_status{name="te.service",status="ok"} 1
+windows_service_status{name="te.service",status="pred fail"} 0
+windows_service_status{name="te.service",status="service"} 0
+windows_service_status{name="te.service",status="starting"} 0
+windows_service_status{name="te.service",status="stopping"} 0
+windows_service_status{name="te.service",status="stressed"} 0
+windows_service_status{name="te.service",status="unknown"} 0
 windows_service_status{name="termservice",status="degraded"} 0
 windows_service_status{name="termservice",status="error"} 0
 windows_service_status{name="termservice",status="lost comm"} 0
@@ -4500,18 +5902,6 @@ windows_service_status{name="tieringengineservice",status="starting"} 0
 windows_service_status{name="tieringengineservice",status="stopping"} 0
 windows_service_status{name="tieringengineservice",status="stressed"} 0
 windows_service_status{name="tieringengineservice",status="unknown"} 0
-windows_service_status{name="tiledatamodelsvc",status="degraded"} 0
-windows_service_status{name="tiledatamodelsvc",status="error"} 0
-windows_service_status{name="tiledatamodelsvc",status="lost comm"} 0
-windows_service_status{name="tiledatamodelsvc",status="no contact"} 0
-windows_service_status{name="tiledatamodelsvc",status="nonrecover"} 0
-windows_service_status{name="tiledatamodelsvc",status="ok"} 1
-windows_service_status{name="tiledatamodelsvc",status="pred fail"} 0
-windows_service_status{name="tiledatamodelsvc",status="service"} 0
-windows_service_status{name="tiledatamodelsvc",status="starting"} 0
-windows_service_status{name="tiledatamodelsvc",status="stopping"} 0
-windows_service_status{name="tiledatamodelsvc",status="stressed"} 0
-windows_service_status{name="tiledatamodelsvc",status="unknown"} 0
 windows_service_status{name="timebrokersvc",status="degraded"} 0
 windows_service_status{name="timebrokersvc",status="error"} 0
 windows_service_status{name="timebrokersvc",status="lost comm"} 0
@@ -4524,6 +5914,18 @@ windows_service_status{name="timebrokersvc",status="starting"} 0
 windows_service_status{name="timebrokersvc",status="stopping"} 0
 windows_service_status{name="timebrokersvc",status="stressed"} 0
 windows_service_status{name="timebrokersvc",status="unknown"} 0
+windows_service_status{name="tokenbroker",status="degraded"} 0
+windows_service_status{name="tokenbroker",status="error"} 0
+windows_service_status{name="tokenbroker",status="lost comm"} 0
+windows_service_status{name="tokenbroker",status="no contact"} 0
+windows_service_status{name="tokenbroker",status="nonrecover"} 0
+windows_service_status{name="tokenbroker",status="ok"} 1
+windows_service_status{name="tokenbroker",status="pred fail"} 0
+windows_service_status{name="tokenbroker",status="service"} 0
+windows_service_status{name="tokenbroker",status="starting"} 0
+windows_service_status{name="tokenbroker",status="stopping"} 0
+windows_service_status{name="tokenbroker",status="stressed"} 0
+windows_service_status{name="tokenbroker",status="unknown"} 0
 windows_service_status{name="trkwks",status="degraded"} 0
 windows_service_status{name="trkwks",status="error"} 0
 windows_service_status{name="trkwks",status="lost comm"} 0
@@ -4536,6 +5938,18 @@ windows_service_status{name="trkwks",status="starting"} 0
 windows_service_status{name="trkwks",status="stopping"} 0
 windows_service_status{name="trkwks",status="stressed"} 0
 windows_service_status{name="trkwks",status="unknown"} 0
+windows_service_status{name="troubleshootingsvc",status="degraded"} 0
+windows_service_status{name="troubleshootingsvc",status="error"} 0
+windows_service_status{name="troubleshootingsvc",status="lost comm"} 0
+windows_service_status{name="troubleshootingsvc",status="no contact"} 0
+windows_service_status{name="troubleshootingsvc",status="nonrecover"} 0
+windows_service_status{name="troubleshootingsvc",status="ok"} 1
+windows_service_status{name="troubleshootingsvc",status="pred fail"} 0
+windows_service_status{name="troubleshootingsvc",status="service"} 0
+windows_service_status{name="troubleshootingsvc",status="starting"} 0
+windows_service_status{name="troubleshootingsvc",status="stopping"} 0
+windows_service_status{name="troubleshootingsvc",status="stressed"} 0
+windows_service_status{name="troubleshootingsvc",status="unknown"} 0
 windows_service_status{name="trustedinstaller",status="degraded"} 0
 windows_service_status{name="trustedinstaller",status="error"} 0
 windows_service_status{name="trustedinstaller",status="lost comm"} 0
@@ -4560,18 +5974,6 @@ windows_service_status{name="tzautoupdate",status="starting"} 0
 windows_service_status{name="tzautoupdate",status="stopping"} 0
 windows_service_status{name="tzautoupdate",status="stressed"} 0
 windows_service_status{name="tzautoupdate",status="unknown"} 0
-windows_service_status{name="ualsvc",status="degraded"} 0
-windows_service_status{name="ualsvc",status="error"} 0
-windows_service_status{name="ualsvc",status="lost comm"} 0
-windows_service_status{name="ualsvc",status="no contact"} 0
-windows_service_status{name="ualsvc",status="nonrecover"} 0
-windows_service_status{name="ualsvc",status="ok"} 1
-windows_service_status{name="ualsvc",status="pred fail"} 0
-windows_service_status{name="ualsvc",status="service"} 0
-windows_service_status{name="ualsvc",status="starting"} 0
-windows_service_status{name="ualsvc",status="stopping"} 0
-windows_service_status{name="ualsvc",status="stressed"} 0
-windows_service_status{name="ualsvc",status="unknown"} 0
 windows_service_status{name="uevagentservice",status="degraded"} 0
 windows_service_status{name="uevagentservice",status="error"} 0
 windows_service_status{name="uevagentservice",status="lost comm"} 0
@@ -4584,18 +5986,6 @@ windows_service_status{name="uevagentservice",status="starting"} 0
 windows_service_status{name="uevagentservice",status="stopping"} 0
 windows_service_status{name="uevagentservice",status="stressed"} 0
 windows_service_status{name="uevagentservice",status="unknown"} 0
-windows_service_status{name="ui0detect",status="degraded"} 0
-windows_service_status{name="ui0detect",status="error"} 0
-windows_service_status{name="ui0detect",status="lost comm"} 0
-windows_service_status{name="ui0detect",status="no contact"} 0
-windows_service_status{name="ui0detect",status="nonrecover"} 0
-windows_service_status{name="ui0detect",status="ok"} 1
-windows_service_status{name="ui0detect",status="pred fail"} 0
-windows_service_status{name="ui0detect",status="service"} 0
-windows_service_status{name="ui0detect",status="starting"} 0
-windows_service_status{name="ui0detect",status="stopping"} 0
-windows_service_status{name="ui0detect",status="stressed"} 0
-windows_service_status{name="ui0detect",status="unknown"} 0
 windows_service_status{name="umrdpservice",status="degraded"} 0
 windows_service_status{name="umrdpservice",status="error"} 0
 windows_service_status{name="umrdpservice",status="lost comm"} 0
@@ -4608,18 +5998,18 @@ windows_service_status{name="umrdpservice",status="starting"} 0
 windows_service_status{name="umrdpservice",status="stopping"} 0
 windows_service_status{name="umrdpservice",status="stressed"} 0
 windows_service_status{name="umrdpservice",status="unknown"} 0
-windows_service_status{name="unistoresvc_225e3",status="degraded"} 0
-windows_service_status{name="unistoresvc_225e3",status="error"} 0
-windows_service_status{name="unistoresvc_225e3",status="lost comm"} 0
-windows_service_status{name="unistoresvc_225e3",status="no contact"} 0
-windows_service_status{name="unistoresvc_225e3",status="nonrecover"} 0
-windows_service_status{name="unistoresvc_225e3",status="ok"} 1
-windows_service_status{name="unistoresvc_225e3",status="pred fail"} 0
-windows_service_status{name="unistoresvc_225e3",status="service"} 0
-windows_service_status{name="unistoresvc_225e3",status="starting"} 0
-windows_service_status{name="unistoresvc_225e3",status="stopping"} 0
-windows_service_status{name="unistoresvc_225e3",status="stressed"} 0
-windows_service_status{name="unistoresvc_225e3",status="unknown"} 0
+windows_service_status{name="unistoresvc_390e7",status="degraded"} 0
+windows_service_status{name="unistoresvc_390e7",status="error"} 0
+windows_service_status{name="unistoresvc_390e7",status="lost comm"} 0
+windows_service_status{name="unistoresvc_390e7",status="no contact"} 0
+windows_service_status{name="unistoresvc_390e7",status="nonrecover"} 0
+windows_service_status{name="unistoresvc_390e7",status="ok"} 1
+windows_service_status{name="unistoresvc_390e7",status="pred fail"} 0
+windows_service_status{name="unistoresvc_390e7",status="service"} 0
+windows_service_status{name="unistoresvc_390e7",status="starting"} 0
+windows_service_status{name="unistoresvc_390e7",status="stopping"} 0
+windows_service_status{name="unistoresvc_390e7",status="stressed"} 0
+windows_service_status{name="unistoresvc_390e7",status="unknown"} 0
 windows_service_status{name="upnphost",status="degraded"} 0
 windows_service_status{name="upnphost",status="error"} 0
 windows_service_status{name="upnphost",status="lost comm"} 0
@@ -4632,18 +6022,18 @@ windows_service_status{name="upnphost",status="starting"} 0
 windows_service_status{name="upnphost",status="stopping"} 0
 windows_service_status{name="upnphost",status="stressed"} 0
 windows_service_status{name="upnphost",status="unknown"} 0
-windows_service_status{name="userdatasvc_225e3",status="degraded"} 0
-windows_service_status{name="userdatasvc_225e3",status="error"} 0
-windows_service_status{name="userdatasvc_225e3",status="lost comm"} 0
-windows_service_status{name="userdatasvc_225e3",status="no contact"} 0
-windows_service_status{name="userdatasvc_225e3",status="nonrecover"} 0
-windows_service_status{name="userdatasvc_225e3",status="ok"} 1
-windows_service_status{name="userdatasvc_225e3",status="pred fail"} 0
-windows_service_status{name="userdatasvc_225e3",status="service"} 0
-windows_service_status{name="userdatasvc_225e3",status="starting"} 0
-windows_service_status{name="userdatasvc_225e3",status="stopping"} 0
-windows_service_status{name="userdatasvc_225e3",status="stressed"} 0
-windows_service_status{name="userdatasvc_225e3",status="unknown"} 0
+windows_service_status{name="userdatasvc_390e7",status="degraded"} 0
+windows_service_status{name="userdatasvc_390e7",status="error"} 0
+windows_service_status{name="userdatasvc_390e7",status="lost comm"} 0
+windows_service_status{name="userdatasvc_390e7",status="no contact"} 0
+windows_service_status{name="userdatasvc_390e7",status="nonrecover"} 0
+windows_service_status{name="userdatasvc_390e7",status="ok"} 1
+windows_service_status{name="userdatasvc_390e7",status="pred fail"} 0
+windows_service_status{name="userdatasvc_390e7",status="service"} 0
+windows_service_status{name="userdatasvc_390e7",status="starting"} 0
+windows_service_status{name="userdatasvc_390e7",status="stopping"} 0
+windows_service_status{name="userdatasvc_390e7",status="stressed"} 0
+windows_service_status{name="userdatasvc_390e7",status="unknown"} 0
 windows_service_status{name="usermanager",status="degraded"} 0
 windows_service_status{name="usermanager",status="error"} 0
 windows_service_status{name="usermanager",status="lost comm"} 0
@@ -4668,6 +6058,18 @@ windows_service_status{name="usosvc",status="starting"} 0
 windows_service_status{name="usosvc",status="stopping"} 0
 windows_service_status{name="usosvc",status="stressed"} 0
 windows_service_status{name="usosvc",status="unknown"} 0
+windows_service_status{name="vacsvc",status="degraded"} 0
+windows_service_status{name="vacsvc",status="error"} 0
+windows_service_status{name="vacsvc",status="lost comm"} 0
+windows_service_status{name="vacsvc",status="no contact"} 0
+windows_service_status{name="vacsvc",status="nonrecover"} 0
+windows_service_status{name="vacsvc",status="ok"} 1
+windows_service_status{name="vacsvc",status="pred fail"} 0
+windows_service_status{name="vacsvc",status="service"} 0
+windows_service_status{name="vacsvc",status="starting"} 0
+windows_service_status{name="vacsvc",status="stopping"} 0
+windows_service_status{name="vacsvc",status="stressed"} 0
+windows_service_status{name="vacsvc",status="unknown"} 0
 windows_service_status{name="vaultsvc",status="degraded"} 0
 windows_service_status{name="vaultsvc",status="error"} 0
 windows_service_status{name="vaultsvc",status="lost comm"} 0
@@ -4824,30 +6226,18 @@ windows_service_status{name="w32time",status="starting"} 0
 windows_service_status{name="w32time",status="stopping"} 0
 windows_service_status{name="w32time",status="stressed"} 0
 windows_service_status{name="w32time",status="unknown"} 0
-windows_service_status{name="w3logsvc",status="degraded"} 0
-windows_service_status{name="w3logsvc",status="error"} 0
-windows_service_status{name="w3logsvc",status="lost comm"} 0
-windows_service_status{name="w3logsvc",status="no contact"} 0
-windows_service_status{name="w3logsvc",status="nonrecover"} 0
-windows_service_status{name="w3logsvc",status="ok"} 1
-windows_service_status{name="w3logsvc",status="pred fail"} 0
-windows_service_status{name="w3logsvc",status="service"} 0
-windows_service_status{name="w3logsvc",status="starting"} 0
-windows_service_status{name="w3logsvc",status="stopping"} 0
-windows_service_status{name="w3logsvc",status="stressed"} 0
-windows_service_status{name="w3logsvc",status="unknown"} 0
-windows_service_status{name="w3svc",status="degraded"} 0
-windows_service_status{name="w3svc",status="error"} 0
-windows_service_status{name="w3svc",status="lost comm"} 0
-windows_service_status{name="w3svc",status="no contact"} 0
-windows_service_status{name="w3svc",status="nonrecover"} 0
-windows_service_status{name="w3svc",status="ok"} 1
-windows_service_status{name="w3svc",status="pred fail"} 0
-windows_service_status{name="w3svc",status="service"} 0
-windows_service_status{name="w3svc",status="starting"} 0
-windows_service_status{name="w3svc",status="stopping"} 0
-windows_service_status{name="w3svc",status="stressed"} 0
-windows_service_status{name="w3svc",status="unknown"} 0
+windows_service_status{name="waasmedicsvc",status="degraded"} 0
+windows_service_status{name="waasmedicsvc",status="error"} 0
+windows_service_status{name="waasmedicsvc",status="lost comm"} 0
+windows_service_status{name="waasmedicsvc",status="no contact"} 0
+windows_service_status{name="waasmedicsvc",status="nonrecover"} 0
+windows_service_status{name="waasmedicsvc",status="ok"} 1
+windows_service_status{name="waasmedicsvc",status="pred fail"} 0
+windows_service_status{name="waasmedicsvc",status="service"} 0
+windows_service_status{name="waasmedicsvc",status="starting"} 0
+windows_service_status{name="waasmedicsvc",status="stopping"} 0
+windows_service_status{name="waasmedicsvc",status="stressed"} 0
+windows_service_status{name="waasmedicsvc",status="unknown"} 0
 windows_service_status{name="walletservice",status="degraded"} 0
 windows_service_status{name="walletservice",status="error"} 0
 windows_service_status{name="walletservice",status="lost comm"} 0
@@ -4860,18 +6250,30 @@ windows_service_status{name="walletservice",status="starting"} 0
 windows_service_status{name="walletservice",status="stopping"} 0
 windows_service_status{name="walletservice",status="stressed"} 0
 windows_service_status{name="walletservice",status="unknown"} 0
-windows_service_status{name="was",status="degraded"} 0
-windows_service_status{name="was",status="error"} 0
-windows_service_status{name="was",status="lost comm"} 0
-windows_service_status{name="was",status="no contact"} 0
-windows_service_status{name="was",status="nonrecover"} 0
-windows_service_status{name="was",status="ok"} 1
-windows_service_status{name="was",status="pred fail"} 0
-windows_service_status{name="was",status="service"} 0
-windows_service_status{name="was",status="starting"} 0
-windows_service_status{name="was",status="stopping"} 0
-windows_service_status{name="was",status="stressed"} 0
-windows_service_status{name="was",status="unknown"} 0
+windows_service_status{name="warpjitsvc",status="degraded"} 0
+windows_service_status{name="warpjitsvc",status="error"} 0
+windows_service_status{name="warpjitsvc",status="lost comm"} 0
+windows_service_status{name="warpjitsvc",status="no contact"} 0
+windows_service_status{name="warpjitsvc",status="nonrecover"} 0
+windows_service_status{name="warpjitsvc",status="ok"} 1
+windows_service_status{name="warpjitsvc",status="pred fail"} 0
+windows_service_status{name="warpjitsvc",status="service"} 0
+windows_service_status{name="warpjitsvc",status="starting"} 0
+windows_service_status{name="warpjitsvc",status="stopping"} 0
+windows_service_status{name="warpjitsvc",status="stressed"} 0
+windows_service_status{name="warpjitsvc",status="unknown"} 0
+windows_service_status{name="wbengine",status="degraded"} 0
+windows_service_status{name="wbengine",status="error"} 0
+windows_service_status{name="wbengine",status="lost comm"} 0
+windows_service_status{name="wbengine",status="no contact"} 0
+windows_service_status{name="wbengine",status="nonrecover"} 0
+windows_service_status{name="wbengine",status="ok"} 1
+windows_service_status{name="wbengine",status="pred fail"} 0
+windows_service_status{name="wbengine",status="service"} 0
+windows_service_status{name="wbengine",status="starting"} 0
+windows_service_status{name="wbengine",status="stopping"} 0
+windows_service_status{name="wbengine",status="stressed"} 0
+windows_service_status{name="wbengine",status="unknown"} 0
 windows_service_status{name="wbiosrvc",status="degraded"} 0
 windows_service_status{name="wbiosrvc",status="error"} 0
 windows_service_status{name="wbiosrvc",status="lost comm"} 0
@@ -4896,6 +6298,18 @@ windows_service_status{name="wcmsvc",status="starting"} 0
 windows_service_status{name="wcmsvc",status="stopping"} 0
 windows_service_status{name="wcmsvc",status="stressed"} 0
 windows_service_status{name="wcmsvc",status="unknown"} 0
+windows_service_status{name="wcncsvc",status="degraded"} 0
+windows_service_status{name="wcncsvc",status="error"} 0
+windows_service_status{name="wcncsvc",status="lost comm"} 0
+windows_service_status{name="wcncsvc",status="no contact"} 0
+windows_service_status{name="wcncsvc",status="nonrecover"} 0
+windows_service_status{name="wcncsvc",status="ok"} 1
+windows_service_status{name="wcncsvc",status="pred fail"} 0
+windows_service_status{name="wcncsvc",status="service"} 0
+windows_service_status{name="wcncsvc",status="starting"} 0
+windows_service_status{name="wcncsvc",status="stopping"} 0
+windows_service_status{name="wcncsvc",status="stressed"} 0
+windows_service_status{name="wcncsvc",status="unknown"} 0
 windows_service_status{name="wdiservicehost",status="degraded"} 0
 windows_service_status{name="wdiservicehost",status="error"} 0
 windows_service_status{name="wdiservicehost",status="lost comm"} 0
@@ -4932,6 +6346,18 @@ windows_service_status{name="wdnissvc",status="starting"} 0
 windows_service_status{name="wdnissvc",status="stopping"} 0
 windows_service_status{name="wdnissvc",status="stressed"} 0
 windows_service_status{name="wdnissvc",status="unknown"} 0
+windows_service_status{name="webclient",status="degraded"} 0
+windows_service_status{name="webclient",status="error"} 0
+windows_service_status{name="webclient",status="lost comm"} 0
+windows_service_status{name="webclient",status="no contact"} 0
+windows_service_status{name="webclient",status="nonrecover"} 0
+windows_service_status{name="webclient",status="ok"} 1
+windows_service_status{name="webclient",status="pred fail"} 0
+windows_service_status{name="webclient",status="service"} 0
+windows_service_status{name="webclient",status="starting"} 0
+windows_service_status{name="webclient",status="stopping"} 0
+windows_service_status{name="webclient",status="stressed"} 0
+windows_service_status{name="webclient",status="unknown"} 0
 windows_service_status{name="wecsvc",status="degraded"} 0
 windows_service_status{name="wecsvc",status="error"} 0
 windows_service_status{name="wecsvc",status="lost comm"} 0
@@ -4980,6 +6406,18 @@ windows_service_status{name="wersvc",status="starting"} 0
 windows_service_status{name="wersvc",status="stopping"} 0
 windows_service_status{name="wersvc",status="stressed"} 0
 windows_service_status{name="wersvc",status="unknown"} 0
+windows_service_status{name="wfdsconmgrsvc",status="degraded"} 0
+windows_service_status{name="wfdsconmgrsvc",status="error"} 0
+windows_service_status{name="wfdsconmgrsvc",status="lost comm"} 0
+windows_service_status{name="wfdsconmgrsvc",status="no contact"} 0
+windows_service_status{name="wfdsconmgrsvc",status="nonrecover"} 0
+windows_service_status{name="wfdsconmgrsvc",status="ok"} 1
+windows_service_status{name="wfdsconmgrsvc",status="pred fail"} 0
+windows_service_status{name="wfdsconmgrsvc",status="service"} 0
+windows_service_status{name="wfdsconmgrsvc",status="starting"} 0
+windows_service_status{name="wfdsconmgrsvc",status="stopping"} 0
+windows_service_status{name="wfdsconmgrsvc",status="stressed"} 0
+windows_service_status{name="wfdsconmgrsvc",status="unknown"} 0
 windows_service_status{name="wiarpc",status="degraded"} 0
 windows_service_status{name="wiarpc",status="error"} 0
 windows_service_status{name="wiarpc",status="lost comm"} 0
@@ -5052,6 +6490,18 @@ windows_service_status{name="wisvc",status="starting"} 0
 windows_service_status{name="wisvc",status="stopping"} 0
 windows_service_status{name="wisvc",status="stressed"} 0
 windows_service_status{name="wisvc",status="unknown"} 0
+windows_service_status{name="wlansvc",status="degraded"} 0
+windows_service_status{name="wlansvc",status="error"} 0
+windows_service_status{name="wlansvc",status="lost comm"} 0
+windows_service_status{name="wlansvc",status="no contact"} 0
+windows_service_status{name="wlansvc",status="nonrecover"} 0
+windows_service_status{name="wlansvc",status="ok"} 1
+windows_service_status{name="wlansvc",status="pred fail"} 0
+windows_service_status{name="wlansvc",status="service"} 0
+windows_service_status{name="wlansvc",status="starting"} 0
+windows_service_status{name="wlansvc",status="stopping"} 0
+windows_service_status{name="wlansvc",status="stressed"} 0
+windows_service_status{name="wlansvc",status="unknown"} 0
 windows_service_status{name="wlidsvc",status="degraded"} 0
 windows_service_status{name="wlidsvc",status="error"} 0
 windows_service_status{name="wlidsvc",status="lost comm"} 0
@@ -5076,18 +6526,30 @@ windows_service_status{name="wlms",status="starting"} 0
 windows_service_status{name="wlms",status="stopping"} 0
 windows_service_status{name="wlms",status="stressed"} 0
 windows_service_status{name="wlms",status="unknown"} 0
-windows_service_status{name="windows_exporter",status="degraded"} 0
-windows_service_status{name="windows_exporter",status="error"} 0
-windows_service_status{name="windows_exporter",status="lost comm"} 0
-windows_service_status{name="windows_exporter",status="no contact"} 0
-windows_service_status{name="windows_exporter",status="nonrecover"} 0
-windows_service_status{name="windows_exporter",status="ok"} 1
-windows_service_status{name="windows_exporter",status="pred fail"} 0
-windows_service_status{name="windows_exporter",status="service"} 0
-windows_service_status{name="windows_exporter",status="starting"} 0
-windows_service_status{name="windows_exporter",status="stopping"} 0
-windows_service_status{name="windows_exporter",status="stressed"} 0
-windows_service_status{name="windows_exporter",status="unknown"} 0
+windows_service_status{name="wlpasvc",status="degraded"} 0
+windows_service_status{name="wlpasvc",status="error"} 0
+windows_service_status{name="wlpasvc",status="lost comm"} 0
+windows_service_status{name="wlpasvc",status="no contact"} 0
+windows_service_status{name="wlpasvc",status="nonrecover"} 0
+windows_service_status{name="wlpasvc",status="ok"} 1
+windows_service_status{name="wlpasvc",status="pred fail"} 0
+windows_service_status{name="wlpasvc",status="service"} 0
+windows_service_status{name="wlpasvc",status="starting"} 0
+windows_service_status{name="wlpasvc",status="stopping"} 0
+windows_service_status{name="wlpasvc",status="stressed"} 0
+windows_service_status{name="wlpasvc",status="unknown"} 0
+windows_service_status{name="wmansvc",status="degraded"} 0
+windows_service_status{name="wmansvc",status="error"} 0
+windows_service_status{name="wmansvc",status="lost comm"} 0
+windows_service_status{name="wmansvc",status="no contact"} 0
+windows_service_status{name="wmansvc",status="nonrecover"} 0
+windows_service_status{name="wmansvc",status="ok"} 1
+windows_service_status{name="wmansvc",status="pred fail"} 0
+windows_service_status{name="wmansvc",status="service"} 0
+windows_service_status{name="wmansvc",status="starting"} 0
+windows_service_status{name="wmansvc",status="stopping"} 0
+windows_service_status{name="wmansvc",status="stressed"} 0
+windows_service_status{name="wmansvc",status="unknown"} 0
 windows_service_status{name="wmiapsrv",status="degraded"} 0
 windows_service_status{name="wmiapsrv",status="error"} 0
 windows_service_status{name="wmiapsrv",status="lost comm"} 0
@@ -5100,6 +6562,42 @@ windows_service_status{name="wmiapsrv",status="starting"} 0
 windows_service_status{name="wmiapsrv",status="stopping"} 0
 windows_service_status{name="wmiapsrv",status="stressed"} 0
 windows_service_status{name="wmiapsrv",status="unknown"} 0
+windows_service_status{name="wmpnetworksvc",status="degraded"} 0
+windows_service_status{name="wmpnetworksvc",status="error"} 0
+windows_service_status{name="wmpnetworksvc",status="lost comm"} 0
+windows_service_status{name="wmpnetworksvc",status="no contact"} 0
+windows_service_status{name="wmpnetworksvc",status="nonrecover"} 0
+windows_service_status{name="wmpnetworksvc",status="ok"} 1
+windows_service_status{name="wmpnetworksvc",status="pred fail"} 0
+windows_service_status{name="wmpnetworksvc",status="service"} 0
+windows_service_status{name="wmpnetworksvc",status="starting"} 0
+windows_service_status{name="wmpnetworksvc",status="stopping"} 0
+windows_service_status{name="wmpnetworksvc",status="stressed"} 0
+windows_service_status{name="wmpnetworksvc",status="unknown"} 0
+windows_service_status{name="workfolderssvc",status="degraded"} 0
+windows_service_status{name="workfolderssvc",status="error"} 0
+windows_service_status{name="workfolderssvc",status="lost comm"} 0
+windows_service_status{name="workfolderssvc",status="no contact"} 0
+windows_service_status{name="workfolderssvc",status="nonrecover"} 0
+windows_service_status{name="workfolderssvc",status="ok"} 1
+windows_service_status{name="workfolderssvc",status="pred fail"} 0
+windows_service_status{name="workfolderssvc",status="service"} 0
+windows_service_status{name="workfolderssvc",status="starting"} 0
+windows_service_status{name="workfolderssvc",status="stopping"} 0
+windows_service_status{name="workfolderssvc",status="stressed"} 0
+windows_service_status{name="workfolderssvc",status="unknown"} 0
+windows_service_status{name="wpcmonsvc",status="degraded"} 0
+windows_service_status{name="wpcmonsvc",status="error"} 0
+windows_service_status{name="wpcmonsvc",status="lost comm"} 0
+windows_service_status{name="wpcmonsvc",status="no contact"} 0
+windows_service_status{name="wpcmonsvc",status="nonrecover"} 0
+windows_service_status{name="wpcmonsvc",status="ok"} 1
+windows_service_status{name="wpcmonsvc",status="pred fail"} 0
+windows_service_status{name="wpcmonsvc",status="service"} 0
+windows_service_status{name="wpcmonsvc",status="starting"} 0
+windows_service_status{name="wpcmonsvc",status="stopping"} 0
+windows_service_status{name="wpcmonsvc",status="stressed"} 0
+windows_service_status{name="wpcmonsvc",status="unknown"} 0
 windows_service_status{name="wpdbusenum",status="degraded"} 0
 windows_service_status{name="wpdbusenum",status="error"} 0
 windows_service_status{name="wpdbusenum",status="lost comm"} 0
@@ -5124,18 +6622,30 @@ windows_service_status{name="wpnservice",status="starting"} 0
 windows_service_status{name="wpnservice",status="stopping"} 0
 windows_service_status{name="wpnservice",status="stressed"} 0
 windows_service_status{name="wpnservice",status="unknown"} 0
-windows_service_status{name="wpnuserservice_225e3",status="degraded"} 0
-windows_service_status{name="wpnuserservice_225e3",status="error"} 0
-windows_service_status{name="wpnuserservice_225e3",status="lost comm"} 0
-windows_service_status{name="wpnuserservice_225e3",status="no contact"} 0
-windows_service_status{name="wpnuserservice_225e3",status="nonrecover"} 0
-windows_service_status{name="wpnuserservice_225e3",status="ok"} 1
-windows_service_status{name="wpnuserservice_225e3",status="pred fail"} 0
-windows_service_status{name="wpnuserservice_225e3",status="service"} 0
-windows_service_status{name="wpnuserservice_225e3",status="starting"} 0
-windows_service_status{name="wpnuserservice_225e3",status="stopping"} 0
-windows_service_status{name="wpnuserservice_225e3",status="stressed"} 0
-windows_service_status{name="wpnuserservice_225e3",status="unknown"} 0
+windows_service_status{name="wpnuserservice_390e7",status="degraded"} 0
+windows_service_status{name="wpnuserservice_390e7",status="error"} 0
+windows_service_status{name="wpnuserservice_390e7",status="lost comm"} 0
+windows_service_status{name="wpnuserservice_390e7",status="no contact"} 0
+windows_service_status{name="wpnuserservice_390e7",status="nonrecover"} 0
+windows_service_status{name="wpnuserservice_390e7",status="ok"} 1
+windows_service_status{name="wpnuserservice_390e7",status="pred fail"} 0
+windows_service_status{name="wpnuserservice_390e7",status="service"} 0
+windows_service_status{name="wpnuserservice_390e7",status="starting"} 0
+windows_service_status{name="wpnuserservice_390e7",status="stopping"} 0
+windows_service_status{name="wpnuserservice_390e7",status="stressed"} 0
+windows_service_status{name="wpnuserservice_390e7",status="unknown"} 0
+windows_service_status{name="wscsvc",status="degraded"} 0
+windows_service_status{name="wscsvc",status="error"} 0
+windows_service_status{name="wscsvc",status="lost comm"} 0
+windows_service_status{name="wscsvc",status="no contact"} 0
+windows_service_status{name="wscsvc",status="nonrecover"} 0
+windows_service_status{name="wscsvc",status="ok"} 1
+windows_service_status{name="wscsvc",status="pred fail"} 0
+windows_service_status{name="wscsvc",status="service"} 0
+windows_service_status{name="wscsvc",status="starting"} 0
+windows_service_status{name="wscsvc",status="stopping"} 0
+windows_service_status{name="wscsvc",status="stressed"} 0
+windows_service_status{name="wscsvc",status="unknown"} 0
 windows_service_status{name="wsearch",status="degraded"} 0
 windows_service_status{name="wsearch",status="error"} 0
 windows_service_status{name="wsearch",status="lost comm"} 0
@@ -5160,18 +6670,18 @@ windows_service_status{name="wuauserv",status="starting"} 0
 windows_service_status{name="wuauserv",status="stopping"} 0
 windows_service_status{name="wuauserv",status="stressed"} 0
 windows_service_status{name="wuauserv",status="unknown"} 0
-windows_service_status{name="wudfsvc",status="degraded"} 0
-windows_service_status{name="wudfsvc",status="error"} 0
-windows_service_status{name="wudfsvc",status="lost comm"} 0
-windows_service_status{name="wudfsvc",status="no contact"} 0
-windows_service_status{name="wudfsvc",status="nonrecover"} 0
-windows_service_status{name="wudfsvc",status="ok"} 1
-windows_service_status{name="wudfsvc",status="pred fail"} 0
-windows_service_status{name="wudfsvc",status="service"} 0
-windows_service_status{name="wudfsvc",status="starting"} 0
-windows_service_status{name="wudfsvc",status="stopping"} 0
-windows_service_status{name="wudfsvc",status="stressed"} 0
-windows_service_status{name="wudfsvc",status="unknown"} 0
+windows_service_status{name="wwansvc",status="degraded"} 0
+windows_service_status{name="wwansvc",status="error"} 0
+windows_service_status{name="wwansvc",status="lost comm"} 0
+windows_service_status{name="wwansvc",status="no contact"} 0
+windows_service_status{name="wwansvc",status="nonrecover"} 0
+windows_service_status{name="wwansvc",status="ok"} 1
+windows_service_status{name="wwansvc",status="pred fail"} 0
+windows_service_status{name="wwansvc",status="service"} 0
+windows_service_status{name="wwansvc",status="starting"} 0
+windows_service_status{name="wwansvc",status="stopping"} 0
+windows_service_status{name="wwansvc",status="stressed"} 0
+windows_service_status{name="wwansvc",status="unknown"} 0
 windows_service_status{name="xblauthmanager",status="degraded"} 0
 windows_service_status{name="xblauthmanager",status="error"} 0
 windows_service_status{name="xblauthmanager",status="lost comm"} 0
@@ -5196,3 +6706,27 @@ windows_service_status{name="xblgamesave",status="starting"} 0
 windows_service_status{name="xblgamesave",status="stopping"} 0
 windows_service_status{name="xblgamesave",status="stressed"} 0
 windows_service_status{name="xblgamesave",status="unknown"} 0
+windows_service_status{name="xboxgipsvc",status="degraded"} 0
+windows_service_status{name="xboxgipsvc",status="error"} 0
+windows_service_status{name="xboxgipsvc",status="lost comm"} 0
+windows_service_status{name="xboxgipsvc",status="no contact"} 0
+windows_service_status{name="xboxgipsvc",status="nonrecover"} 0
+windows_service_status{name="xboxgipsvc",status="ok"} 1
+windows_service_status{name="xboxgipsvc",status="pred fail"} 0
+windows_service_status{name="xboxgipsvc",status="service"} 0
+windows_service_status{name="xboxgipsvc",status="starting"} 0
+windows_service_status{name="xboxgipsvc",status="stopping"} 0
+windows_service_status{name="xboxgipsvc",status="stressed"} 0
+windows_service_status{name="xboxgipsvc",status="unknown"} 0
+windows_service_status{name="xboxnetapisvc",status="degraded"} 0
+windows_service_status{name="xboxnetapisvc",status="error"} 0
+windows_service_status{name="xboxnetapisvc",status="lost comm"} 0
+windows_service_status{name="xboxnetapisvc",status="no contact"} 0
+windows_service_status{name="xboxnetapisvc",status="nonrecover"} 0
+windows_service_status{name="xboxnetapisvc",status="ok"} 1
+windows_service_status{name="xboxnetapisvc",status="pred fail"} 0
+windows_service_status{name="xboxnetapisvc",status="service"} 0
+windows_service_status{name="xboxnetapisvc",status="starting"} 0
+windows_service_status{name="xboxnetapisvc",status="stopping"} 0
+windows_service_status{name="xboxnetapisvc",status="stressed"} 0
+windows_service_status{name="xboxnetapisvc",status="unknown"} 0

--- a/test/json-schema-files/winservices-schema.json
+++ b/test/json-schema-files/winservices-schema.json
@@ -70,6 +70,10 @@
                     "minLength": 1,
                     "type": "string"
                   },
+                  "windowsService.runAs": {
+                    "minLength": 0,
+                    "type": "string"
+                  },
                   "windowsService.startMode": {
                     "pattern": "^(boot|system|auto|manual|disabled)$",
                     "type": "string"
@@ -81,6 +85,7 @@
                   "windowsService.hostname",
                   "windowsService.name",
                   "windowsService.processId",
+                  "windowsService.runAs",
                   "windowsService.startMode"
                 ]
               }
@@ -161,6 +166,10 @@
                   "windowsService.processId": {
                     "type": "string"
                   },
+                  "windowsService.runAs": {
+                    "type": "string",
+                    "minLength": 0
+                  },
                   "windowsService.startMode": {
                     "type": "string"
                   },
@@ -178,6 +187,7 @@
                   "windowsService.hostname",
                   "windowsService.name",
                   "windowsService.processId",
+                  "windowsService.runAs",
                   "windowsService.startMode",
                   "windowsService.state",
                   "windowsService.status"

--- a/win_build.ps1
+++ b/win_build.ps1
@@ -22,7 +22,7 @@ $commitHash = (git rev-parse HEAD)
 $exporterRepo = "github.com\prometheus-community\windows_exporter"
 $exporterBinaryName = "windows_exporter.exe"
 # Commit used by v0.12.0 of windows_exporter
-$exporterVersion = "eff5f2415398d89173a2203c47366e4882f3bc0e"
+$exporterVersion = "c9f1e5068a267aeb3e8cff47bc5323cbc050055a"
 # Collector used by the Windows Service integration
 $collectors = "collector.go","wmi.go","perflib.go","service.go","cs.go"
 


### PR DESCRIPTION

Adding info regarding run_as for windows service

Account name under which a service runs. Depending on the service type, the account name may be in the form of DomainName/Username or UPN format (Username@DomainName). 

It corresponds to the StartName attribute of the Win32_Service class. StartName attribute can be NULL and in such case the label is reported as an empty string. Notice that if the attribute is NULL the service is logged on as the LocalSystem account or, for kernel or system-level drive, it runs with a default object name created by the I/O system based on the service name, for example, DWDOM/Admin.



