### PR TITLE
feat(CI/CD): added Snyk action to check dependencies

### DIFF
--- a/.github/workflows/snykDependencies.yml
+++ b/.github/workflows/snykDependencies.yml
@@ -1,0 +1,18 @@
+name: Snyk Dependencies
+on:
+  push:
+    # Not enabled for PRs since github secrets are not available
+    branches: [ master ]
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/golang@master
+        env:
+          # snyk token, set trough github secrets
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          # snyk monitor run the tests and uploads the results in the corresponding page
+          command: monitor


### PR DESCRIPTION
# Description

This action will add support for Snyk dependency check, the token is not available for Pull Requests. 
We will be able to properly add the Snyk application once `go modules` will be supported not merely in the CLI

[Tested in a fork.](https://github.com/gallo-cedrone/nri-winservices/runs/762361872)


# Checklist:

- [x] I checked that Licenses of new dependencies is compliant with our guidelines
- [x] I have performed a self-review of my own code
- [x] I have added comments in my code to clarify it
- [x] I cleaned the commit history, and they are following [the conventional commits pattern](https://www.conventionalcommits.org/en/v1.0.0/)


