### PR TITLE
feat(CI/CD): added changelog definition for releases

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,40 @@
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]({{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}){{ else }}{{ .Tag.Name }}{{ end }}
+
+> {{ datetime "2006-01-02" .Tag.Date }}
+
+{{ range .CommitGroups -}}
+### {{ .Title }}
+
+{{ range .Commits -}}
+* {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+
+{{- if .RevertCommits -}}
+### Reverts
+
+{{ range .RevertCommits -}}
+* {{ .Revert.Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .MergeCommits -}}
+### Pull Requests
+
+{{ range .MergeCommits -}}
+* {{ .Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,28 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/newrelic/nri-winservices
+options:
+  commits:
+    # filters:
+    #   Type:
+    #     - feat
+    #     - fix
+    #     - perf
+    #     - refactor
+  commit_groups:
+    # title_maps:
+    #   feat: Features
+    #   fix: Bug Fixes
+    #   perf: Performance Improvements
+    #   refactor: Code Refactoring
+  header:
+    pattern: "^(\\w*)(?:\\(([\\w\\$\\.\\-\\*\\s\\/]*)\\))?\\:\\s(.*)$"
+    pattern_maps:
+      - Type
+      - Scope
+      - Subject
+  notes:
+    keywords:
+      - BREAKING CHANGE

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 # nri-winservices
 ![](https://github.com/newrelic/nri-winservices/workflows/PullRequestAndMergeMaster/badge.svg)
 ![](https://github.com/newrelic/nri-winservices/workflows/Release/badge.svg)
+![Snyk Dependencies](https://github.com/newrelic/nri-winservices/workflows/Snyk%20Dependencies/badge.svg)
 
 New Relic's Windows Services integration collects data from the services running on your Windows hosts into our platform. You can check the state, status, and start mode of each service, find out which hosts are running a service, add services to 
  workloads, set up alerts for services, and more.
@@ -36,6 +37,12 @@ Once built, the integration can be tested running `nri-winservices.exe`, which i
 ```powershell
 PS .\nri-winservices.exe -config_path "../../../test/config.yml"
 ```
+
+## Changelog
+
+Changelog of releases is create by running `git-chglog  --next-tag v0.0.0`. 
+
+Commit messages not following [the conventional commits pattern](https://www.conventionalcommits.org/en/v1.0.0/)  (es: `type(scope): what I have changed`) will be not included in the Changelog.
 
 ## Support
 


### PR DESCRIPTION
# Description

Added configuration for the changelog that we can use for release notes.
Following the commit pattern it will be enough to create the changelog on Release
I am not a fan of keeping the changelog in the repo since it creates often issues (not updated and merge conflicts not possible to edit them)


Example of Changelog generate for next tag:
-
<a name="0.3.0"></a>
## [0.3.0](https://github.com/newrelic/nri-winservices/compare/v0.0.2...0.3.0)

> 2020-06-12

### Feat

* Added account info for winservice ([#29](https://github.com/newrelic/nri-winservices/issues/29))
* **CI/CD:** added changelog definition for releases
* **CI/CD:** added Snyk action to check dependencies ([#31](https://github.com/newrelic/nri-winservices/issues/31))
* **GithubActions:** integration tests ([#24](https://github.com/newrelic/nri-winservices/issues/24))
* **license:** Added third party notice ([#30](https://github.com/newrelic/nri-winservices/issues/30))
* **release:** Adding zip support ([#23](https://github.com/newrelic/nri-winservices/issues/23))

### Fix

* **config:** fixed config file name ([#28](https://github.com/newrelic/nri-winservices/issues/28))
* **config:** binary path now pointing to correct folder ([#27](https://github.com/newrelic/nri-winservices/issues/27))

### Pull Requests

* Merge pull request [#26](https://github.com/newrelic/nri-winservices/issues/26) from newrelic/theletterf-patch-1
* Merge pull request [#21](https://github.com/newrelic/nri-winservices/issues/21) from newrelic/feat/githubActionMaster

# Checklist:

- [x] I checked that Licenses of new dependencies is compliant with our guidelines
- [x] I have performed a self-review of my own code
- [x] I have added comments in my code to clarify it
- [x] I have updated the documentation accordingly
- [x] I cleaned the commit history, and they are following [the conventional commits pattern](https://www.conventionalcommits.org/en/v1.0.0/), es:
    
      `type(scope): what I have changed`


