### PR TITLE
fix(Matcher): make regex non case sentitive

### DIFF
--- a/src/matcher/matcher.go
+++ b/src/matcher/matcher.go
@@ -74,7 +74,8 @@ func New(filters []string) Matcher {
 		if !isRegex {
 			filter = "^" + regexp.QuoteMeta(filter) + "$"
 		}
-		reg, err := regexp.Compile(filter)
+		// windows services names are collected in lower case, (?i) is the case insensitive flag
+		reg, err := regexp.Compile("(?i)" + filter)
 		if err != nil {
 			log.Warn("failed to compile regex:%s err:%v", reg, err)
 			continue

--- a/src/matcher/matcher_test.go
+++ b/src/matcher/matcher_test.go
@@ -15,7 +15,7 @@ func TestMatcherMatch(t *testing.T) {
 	var filterList = []string{
 		`customImportantService`,
 		`"special.?^ServiceWithSpecialChars" #Comments`,
-		`regex "important.*$" #Comments`,
+		`regex "^Important.*$" #Comments`,
 		`regex`,
 		`regex .*`,
 		`.*`,
@@ -24,10 +24,10 @@ func TestMatcherMatch(t *testing.T) {
 
 	m := New(filterList)
 
-	assert.True(t, m.Match("customImportantService"))
+	assert.True(t, m.Match("customimportantservice"))
 	assert.True(t, m.Match("special.?^ServiceWithSpecialChars"))
 	assert.True(t, m.Match("importantServiceSub"))
 	assert.True(t, m.Match("quoted"))
-	assert.True(t, m.Match("importantServiceSub"))
+	assert.False(t, m.Match("notimportantService"))
 	assert.False(t, m.Match("randomService"))
 }


### PR DESCRIPTION
# Description

Make literal and regex filters case insensitive.
Reason:
Windows service names are reported in lower case by the exporter. An user setting up the filters could use the mixed cases from the real name and that service will not be reported. 
es: `WinDefend` is reported as `windefend` by the exporter.

# Checklist:

- [x] I checked that Licenses of new dependencies is compliant with our guidelines
- [x] I have performed a self-review of my own code
- [x] I have added comments in my code to clarify it
- [x] I have updated the documentation accordingly
- [x] I have added tests that show my fix/feature works
- [x] I cleaned the commit history, and they are following [the conventional commits pattern](https://www.conventionalcommits.org/en/v1.0.0/), es:
    
      `type(scope): what I have changed`


