### PR TITLE
fix: Extend timeout config default

### DIFF
--- a/winservices-config.yml.sample
+++ b/winservices-config.yml.sample
@@ -27,7 +27,7 @@ integrations:
     # sent from the integration. Heartbeats are sent every 5s, so this timeout
     # shouldn't be less than that.
     #
-    timeout: 10s
+    timeout: 60s
 
     # Since this is a long-running integration, interval is ignored. To
     # configure the interval period for collecting and sending data, edit


### PR DESCRIPTION
# Description

We have detected some issues where the exporter takes too long to respond and the integration is being killed by the agent. This extends the default timeout value to avoid that issue.

# Checklist:

- [ ] I checked that Licenses of new dependencies is compliant with our guidelines
- [x] I have performed a self-review of my own code
- [x] I have added comments in my code to clarify it
- [x] I have updated the documentation accordingly
- [x] I have added tests that show my fix/feature works
- [x] I cleaned the commit history, and they are following [the conventional commits pattern](https://www.conventionalcommits.org/en/v1.0.0/), es:
    
      `type(scope): what I have changed`


