### PR TITLE
disable the cs collector to get the hostname without using WMI

### DIFF
--- a/src/exporter/exporter.go
+++ b/src/exporter/exporter.go
@@ -23,7 +23,7 @@ import (
 const (
 	// ExporterName name of the exporter binary
 	ExporterName      = "windows_exporter.exe"
-	enabledCollectors = "service,cs"
+	enabledCollectors = "service"
 	logFormat         = "exporter msg=%v source=%v"
 )
 
@@ -137,11 +137,7 @@ func (e *Exporter) Kill() {
 		return
 	default:
 		e.cancel()
-		if err := e.cmd.Wait(); err != nil {
-			log.Error(err.Error())
-		}
 	}
-
 }
 
 type logMsg struct {

--- a/src/nri/metricsProcesor.go
+++ b/src/nri/metricsProcesor.go
@@ -23,12 +23,11 @@ type metadataMap map[string]string
 type attributesMap map[string]string
 
 // ProcessMetrics creates entities and add metrics from the MetricFamiliesByName according to rules
-func ProcessMetrics(i *integration.Integration, metricFamilyMap scraper.MetricFamiliesByName, matcher matcher.Matcher) error {
+func ProcessMetrics(i *integration.Integration, metricFamilyMap scraper.MetricFamiliesByName, matcher matcher.Matcher, hostname string) error {
 	entityRules := loadRules()
 
-	hostname, err := getHostname(metricFamilyMap, entityRules)
-	if err != nil {
-		return err
+	if hostname == "" {
+		return fmt.Errorf("hostname cannot be empty")
 	}
 
 	entityMap, err := createEntities(i, metricFamilyMap, entityRules, matcher, hostname)
@@ -177,24 +176,6 @@ func getLabelValue(label []*dto.LabelPair, key string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("label %v not found", key)
-}
-
-func getHostname(metricFamilyMap scraper.MetricFamiliesByName, entityRules EntityRules) (string, error) {
-	var hostname string
-	var err error
-
-	mf, ok := metricFamilyMap[entityRules.EntityName.HostnameMetric]
-	if !ok {
-		return "", fmt.Errorf("hostname Metric not found")
-	}
-
-	for _, m := range mf.GetMetric() {
-		hostname, err = getLabelValue(m.GetLabel(), entityRules.EntityName.HostnameLabel)
-		if err != nil {
-			return "", err
-		}
-	}
-	return hostname, nil
 }
 
 func warnOnErr(err error) {

--- a/src/nri/metricsProcesor_test.go
+++ b/src/nri/metricsProcesor_test.go
@@ -6,7 +6,6 @@
 package nri
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/newrelic/infra-integrations-sdk/v4/integration"
@@ -89,23 +88,6 @@ var metricFamlilyService = dto.MetricFamily{
 		},
 	},
 }
-var metricFamlilyServiceHostname = dto.MetricFamily{
-	Name: strPtr("windows_cs_hostname"),
-	Type: &gauge,
-	Metric: []*dto.Metric{
-		{
-			Label: []*dto.LabelPair{
-				{
-					Name:  strPtr("hostname"),
-					Value: strPtr(hostname),
-				},
-			},
-			Gauge: &dto.Gauge{
-				Value: float64Ptr(1),
-			},
-		},
-	},
-}
 
 func TestCreateEntities(t *testing.T) {
 	i, _ := integration.New("integrationName", "integrationVersion")
@@ -113,29 +95,15 @@ func TestCreateEntities(t *testing.T) {
 	mfbn := scraper.MetricFamiliesByName{
 		"windows_service_info":       metricFamlilyServiceInfo,
 		"windows_service_start_mode": metricFamlilyService,
-		"windows_cs_hostname":        metricFamlilyServiceHostname,
 	}
 
-	h, err := getHostname(mfbn, rules)
 	matcher := matcher.New(filter)
-	entityMap, err := createEntities(i, mfbn, rules, matcher, h)
+	entityMap, err := createEntities(i, mfbn, rules, matcher, hostname)
 	require.NoError(t, err)
 	_, ok := entityMap[serviceName]
 	require.True(t, ok)
 	require.Len(t, i.Entities, 1)
 	require.Equal(t, i.Entities[0].Name(), hostname+":"+serviceName)
-}
-
-func TestGetHostnameFail(t *testing.T) {
-	rules := loadRules()
-	mfbn := scraper.MetricFamiliesByName{
-		"windows_service_info":       metricFamlilyServiceInfo,
-		"windows_service_start_mode": metricFamlilyService,
-		// exclude host name metrics from family
-		// "windows_cs_hostname":        metricFamlilyServiceHostname,
-	}
-	_, err := getHostname(mfbn, rules)
-	require.Equal(t, err, errors.New("hostname Metric not found"))
 }
 
 func TestNoServiceNameAllowed(t *testing.T) {
@@ -144,16 +112,14 @@ func TestNoServiceNameAllowed(t *testing.T) {
 	mfbn := scraper.MetricFamiliesByName{
 		"windows_service_info":       metricFamlilyServiceInfo,
 		"windows_service_start_mode": metricFamlilyService,
-		"windows_cs_hostname":        metricFamlilyServiceHostname,
 	}
 
 	matcher := matcher.New([]string{})
-	h, err := getHostname(mfbn, rules)
-	entityMap, err := createEntities(i, mfbn, rules, matcher, h)
+	entityMap, err := createEntities(i, mfbn, rules, matcher, hostname)
 	require.NoError(t, err, "No error is expected even if no service is allowed")
 	require.Len(t, entityMap, 0, "No entity is expected since no service is allowed")
-	err = processMetricGauge(metricFamlilyService, rules, entityMap, h)
-	err = processMetricGauge(metricFamlilyService, rules, entityMap, h)
+	err = processMetricGauge(metricFamlilyService, rules, entityMap, hostname)
+	err = processMetricGauge(metricFamlilyService, rules, entityMap, hostname)
 	require.NoError(t, err)
 	require.NoError(t, err, "No error is expected even if entityMap is empty")
 }
@@ -164,24 +130,21 @@ func TestProccessMetricGauge(t *testing.T) {
 	mfbn := scraper.MetricFamiliesByName{
 		"windows_service_info":       metricFamlilyServiceInfo,
 		"windows_service_start_mode": metricFamlilyService,
-		"windows_cs_hostname":        metricFamlilyServiceHostname,
 	}
 
-	h, err := getHostname(mfbn, rules)
 	matcher := matcher.New(filter)
-	entityMap, err := createEntities(i, mfbn, rules, matcher, h)
+	entityMap, err := createEntities(i, mfbn, rules, matcher, hostname)
 	require.NoError(t, err)
 	// process info metrics
-	err = processMetricGauge(metricFamlilyServiceInfo, rules, entityMap, h)
+	err = processMetricGauge(metricFamlilyServiceInfo, rules, entityMap, hostname)
 	require.NoError(t, err)
 	metadata := entityMap[serviceName].GetMetadata()
 	assert.Equal(t, serviceDisplayName, metadata["windowsService.displayName"])
 	assert.Equal(t, servicePid, metadata["windowsService.processId"])
 	// process startmode metrics
-	err = processMetricGauge(metricFamlilyService, rules, entityMap, h)
+	err = processMetricGauge(metricFamlilyService, rules, entityMap, hostname)
 	assert.NoError(t, err)
 	assert.Equal(t, serviceStartMode, metadata["windowsService.startMode"])
-	assert.Equal(t, hostname, metadata[rules.EntityName.HostnameNrdbLabelName])
 
 }
 

--- a/src/nri/rules.go
+++ b/src/nri/rules.go
@@ -22,8 +22,6 @@ type EntityName struct {
 	Metric                string `yaml:"from_metric"`
 	Label                 string `yaml:"name_label"`
 	DisplayNameLabel      string `yaml:"display_name_label"`
-	HostnameMetric        string `yaml:"hostname_metric"`
-	HostnameLabel         string `yaml:"hostname_label"`
 	HostnameNrdbLabelName string `yaml:"hostname_nrdb_name"`
 }
 
@@ -61,8 +59,6 @@ func loadRules() EntityRules {
 			Metric:                "windows_service_info",
 			Label:                 "name",
 			DisplayNameLabel:      "display_name",
-			HostnameMetric:        "windows_cs_hostname",
-			HostnameLabel:         "hostname",
 			HostnameNrdbLabelName: "windowsService.hostname",
 		},
 		Metrics: []MetricRules{

--- a/src/winservices.go
+++ b/src/winservices.go
@@ -8,6 +8,7 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/newrelic/nri-winservices/src/exporter"
@@ -38,6 +39,8 @@ var (
 	commitHash         = "default" // Commit hash used to build the integration set by -ldflags on build
 )
 
+type hostnameFn func() (name string, err error)
+
 func main() {
 	i, err := integration.New(integrationName, integrationVersion, integration.Args(&args))
 	fatalOnErr(err)
@@ -62,11 +65,11 @@ func main() {
 
 	// After fail the integration is being relaunched by the Agent when timeout expires since no heartbeats are send
 	log.Debug("Running Integration")
-	err = run(e, i, config)
+	err = run(e, i, config, os.Hostname)
 	log.Fatal(err)
 }
 
-func run(e *exporter.Exporter, i *integration.Integration, config *nri.Config) error {
+func run(e *exporter.Exporter, i *integration.Integration, config *nri.Config, hostnameFn hostnameFn) error {
 	defer e.Kill()
 	heartBeat := time.NewTicker(config.HeartBeatPeriod)
 	metricInterval := time.NewTicker(config.ScrapeInterval)
@@ -89,7 +92,12 @@ func run(e *exporter.Exporter, i *integration.Integration, config *nri.Config) e
 			}
 			log.Debug("Metrics scraped, MetricsByFamily found: %d, time elapsed: %s", len(metricsByFamily), time.Since(t).String())
 
-			if err = nri.ProcessMetrics(i, metricsByFamily, config.Matcher); err != nil {
+			hostname, err := hostnameFn()
+			if err != nil {
+				return fmt.Errorf("fail to get the hostname:%v", err)
+			}
+
+			if err = nri.ProcessMetrics(i, metricsByFamily, config.Matcher, hostname); err != nil {
 				return fmt.Errorf("fail to process metrics:%v", err)
 			}
 			log.Debug("Metrics processed, entities found: %d, time elapsed: %s", len(i.Entities), time.Since(t).String())


### PR DESCRIPTION
# Description

As the exporter runs locally along with the integration, we don't need to fetch the hostname from the exporter. Therefore, we can disable the cs collector, thus avoiding one call to WMI.

I've also removed one of the wait calls, because it was already done in the exporter's run gorutine.

# Checklist:

- [x] I checked that Licenses of new dependencies is compliant with our guidelines
- [x] I have performed a self-review of my own code
- [ ] I have added comments in my code to clarify it
- [ ] I have updated the documentation accordingly
- [x] I have added tests that show my fix/feature works
- [x] I cleaned the commit history, and they are following [the conventional commits pattern](https://www.conventionalcommits.org/en/v1.0.0/), es:
    
      `type(scope): what I have changed`


