### PR TITLE
Upgrade windows exporter to v0.29.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.1.0 (2024-12-17)
+### Changed
+- Upgraded the exporter version to v0.29.2
+
 ## 1.0.3 (2024-09-10)
 ### Fixed
 - Bumped dependencies

--- a/src/exporter/exporter.go
+++ b/src/exporter/exporter.go
@@ -58,10 +58,11 @@ func New(verbose bool, bindAddress string, bindPort string) (*Exporter, error) {
 		exporterPath,
 		"--collectors.enabled", enabledCollectors,
 		"--log.level", exporterLogLevel,
-		"--log.format", "logger:stderr?json=true",
-		"--collector.service.use-api",                         // enable collection using windows API instead of WMI
-		"--collector.service.services-where", "Name like '%'", // All Added to avoid warn message from Exporter
-		"--telemetry.addr", exporterURL)
+		"--log.format", "json",
+		// "--collector.service.use-api",                         // enable collection using windows API instead of WMI
+		// "--collector.service.services-where", "Name like '%'", // All Added to avoid warn message from Exporter
+		"--web.listen-address", exporterURL,
+	)
 
 	return &Exporter{
 		URL:        exporterURL,

--- a/src/exporter/exporter.go
+++ b/src/exporter/exporter.go
@@ -59,8 +59,8 @@ func New(verbose bool, bindAddress string, bindPort string) (*Exporter, error) {
 		"--collectors.enabled", enabledCollectors,
 		"--log.level", exporterLogLevel,
 		"--log.format", "json",
-		// "--collector.service.use-api",                         // enable collection using windows API instead of WMI
-		// "--collector.service.services-where", "Name like '%'", // All Added to avoid warn message from Exporter
+		// "--collector.service.use-api", // The WMI based collector is gone used to enable collection using windows API instead of WMI
+		"--collector.service.include", ".*", // All Added to avoid warn message from Exporter
 		"--web.listen-address", exporterURL,
 	)
 

--- a/src/nri/metricsProcesor.go
+++ b/src/nri/metricsProcesor.go
@@ -95,7 +95,7 @@ func createEntities(integrationInstance *integration.Integration, metricFamilyMa
 			continue
 		}
 
-		entityName := fmt.Sprintf("%s:%s:%s", entityNamePrefix, hostName, serviceName)
+		entityName := fmt.Sprintf("%s:%s:%s", entityNamePrefix, hostName, strings.ToLower(serviceName))
 
 		entity, err := integrationInstance.NewEntity(entityName, entityRules.EntityType, serviceDisplayName)
 		if err != nil {
@@ -171,7 +171,8 @@ func processMetricGauge(metricFamily dto.MetricFamily, entityRules EntityRules, 
 func addMetadata(metadata metadataMap, e *integration.Entity) {
 	var err error
 	for k, v := range metadata {
-		// exporter sends service_name in camel case we need to convert it to lowercase
+		// latest version exporter sends service_name in camel case
+		// for consistency we need to convert it to lowercase
 		if k == "service_name" {
 			v = strings.ToLower(v)
 		}

--- a/src/nri/metricsProcesor.go
+++ b/src/nri/metricsProcesor.go
@@ -136,6 +136,7 @@ func processMetricGauge(metricFamily dto.MetricFamily, entityRules EntityRules, 
 		}
 
 		attributes, metadata := getAttributesAndMetadata(entityRules, metricRules.Attributes, m, hostname)
+		// Add process_id to windows_service_info metrics Family
 		if metricFamily.GetName() == "windows_service_info" {
 			winServiceProcess, ok := metricFamilyMap["windows_service_process"]
 			if ok {
@@ -170,7 +171,7 @@ func processMetricGauge(metricFamily dto.MetricFamily, entityRules EntityRules, 
 func addMetadata(metadata metadataMap, e *integration.Entity) {
 	var err error
 	for k, v := range metadata {
-		// exporter sends service_name in camel case
+		// exporter sends service_name in camel case we need to convert it to lowercase
 		if k == "service_name" {
 			v = strings.ToLower(v)
 		}

--- a/src/nri/metricsProcesor.go
+++ b/src/nri/metricsProcesor.go
@@ -7,6 +7,7 @@ package nri
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/newrelic/nri-winservices/src/matcher"
@@ -169,6 +170,10 @@ func processMetricGauge(metricFamily dto.MetricFamily, entityRules EntityRules, 
 func addMetadata(metadata metadataMap, e *integration.Entity) {
 	var err error
 	for k, v := range metadata {
+		// exporter sends service_name in camel case
+		if k == "service_name" {
+			v = strings.ToLower(v)
+		}
 		err = e.AddMetadata(k, v)
 		warnOnErr(err)
 	}

--- a/src/nri/metricsProcesor_test.go
+++ b/src/nri/metricsProcesor_test.go
@@ -89,6 +89,28 @@ var metricFamlilyService = dto.MetricFamily{
 	},
 }
 
+var metricFamlilyServiceProcess = dto.MetricFamily{
+	Name: strPtr("windows_service_process"),
+	Type: &gauge,
+	Metric: []*dto.Metric{
+		{
+			Label: []*dto.LabelPair{
+				{
+					Name:  strPtr("name"),
+					Value: strPtr(serviceName),
+				},
+				{
+					Name:  strPtr("process_id"),
+					Value: strPtr(servicePid),
+				},
+			},
+			Gauge: &dto.Gauge{
+				Value: float64Ptr(1),
+			},
+		},
+	},
+}
+
 func TestCreateEntities(t *testing.T) {
 	i, _ := integration.New("integrationName", "integrationVersion")
 	rules := loadRules()
@@ -131,21 +153,27 @@ func TestProccessMetricGauge(t *testing.T) {
 	mfbn := scraper.MetricFamiliesByName{
 		"windows_service_info":       metricFamlilyServiceInfo,
 		"windows_service_start_mode": metricFamlilyService,
+		"windows_service_process":    metricFamlilyServiceProcess,
 	}
 
 	matcher := matcher.New(filter)
 	entityMap, err := createEntities(i, mfbn, rules, matcher)
 	require.NoError(t, err)
 	// process info metrics
-	err = processMetricGauge(metricFamlilyService, rules, entityMap, mfbn, hostname)
+	err = processMetricGauge(metricFamlilyServiceInfo, rules, entityMap, mfbn, hostname)
 	require.NoError(t, err)
 	metadata := entityMap[serviceName].GetMetadata()
 	assert.Equal(t, serviceDisplayName, metadata["display_name"])
-	assert.Equal(t, servicePid, metadata["process_id"])
+
 	// process startmode metrics
 	err = processMetricGauge(metricFamlilyService, rules, entityMap, mfbn, hostname)
 	assert.NoError(t, err)
 	assert.Equal(t, serviceStartMode, metadata["start_mode"])
+
+	// process start process metrics
+	err = processMetricGauge(metricFamlilyServiceProcess, rules, entityMap, mfbn, hostname)
+	assert.NoError(t, err)
+	assert.Equal(t, servicePid, metadata["process_id"])
 
 }
 

--- a/src/nri/metricsProcesor_test.go
+++ b/src/nri/metricsProcesor_test.go
@@ -119,8 +119,8 @@ func TestNoServiceNameAllowed(t *testing.T) {
 	entityMap, err := createEntities(i, mfbn, rules, matcher)
 	require.NoError(t, err, "No error is expected even if no service is allowed")
 	require.Len(t, entityMap, 0, "No entity is expected since no service is allowed")
-	err = processMetricGauge(metricFamlilyService, rules, entityMap, hostname)
-	err = processMetricGauge(metricFamlilyService, rules, entityMap, hostname)
+	err = processMetricGauge(metricFamlilyService, rules, entityMap, mfbn, hostname)
+	err = processMetricGauge(metricFamlilyService, rules, entityMap, mfbn, hostname)
 	require.NoError(t, err)
 	require.NoError(t, err, "No error is expected even if entityMap is empty")
 }
@@ -137,13 +137,13 @@ func TestProccessMetricGauge(t *testing.T) {
 	entityMap, err := createEntities(i, mfbn, rules, matcher)
 	require.NoError(t, err)
 	// process info metrics
-	err = processMetricGauge(metricFamlilyServiceInfo, rules, entityMap, hostname)
+	err = processMetricGauge(metricFamlilyService, rules, entityMap, mfbn, hostname)
 	require.NoError(t, err)
 	metadata := entityMap[serviceName].GetMetadata()
 	assert.Equal(t, serviceDisplayName, metadata["display_name"])
 	assert.Equal(t, servicePid, metadata["process_id"])
 	// process startmode metrics
-	err = processMetricGauge(metricFamlilyService, rules, entityMap, hostname)
+	err = processMetricGauge(metricFamlilyService, rules, entityMap, mfbn, hostname)
 	assert.NoError(t, err)
 	assert.Equal(t, serviceStartMode, metadata["start_mode"])
 

--- a/src/nri/metricsProcesor_test.go
+++ b/src/nri/metricsProcesor_test.go
@@ -6,6 +6,7 @@
 package nri
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/newrelic/infra-integrations-sdk/v4/integration"
@@ -17,7 +18,7 @@ import (
 )
 
 const (
-	serviceName        = "rpcss"
+	serviceName        = "RpcSs"
 	serviceStartMode   = "auto"
 	serviceDisplayName = "Remote Procedure Call (RPC)"
 	servicePid         = "668"
@@ -125,7 +126,7 @@ func TestCreateEntities(t *testing.T) {
 	_, ok := entityMap[serviceName]
 	require.True(t, ok)
 	require.Len(t, i.Entities, 1)
-	require.Equal(t, i.Entities[0].Name(), entityNamePrefix+":"+hostName+":"+serviceName)
+	require.Equal(t, i.Entities[0].Name(), entityNamePrefix+":"+hostName+":"+strings.ToLower(serviceName))
 	require.False(t, i.Entities[0].IgnoreEntity)
 }
 
@@ -164,6 +165,9 @@ func TestProccessMetricGauge(t *testing.T) {
 	require.NoError(t, err)
 	metadata := entityMap[serviceName].GetMetadata()
 	assert.Equal(t, serviceDisplayName, metadata["display_name"])
+
+	// Service name in lowercase check
+	assert.Equal(t, strings.ToLower(serviceName), metadata["service_name"])
 
 	// process startmode metrics
 	err = processMetricGauge(metricFamlilyService, rules, entityMap, mfbn, hostname)

--- a/src/nri/rules.go
+++ b/src/nri/rules.go
@@ -83,11 +83,6 @@ func loadRules() EntityRules {
 						NrdbLabelName:    "display_name",
 						IsEntityMetadata: true,
 					},
-					{
-						Label:            "process_id",
-						NrdbLabelName:    "process_id",
-						IsEntityMetadata: true,
-					},
 				},
 			},
 			{
@@ -112,6 +107,24 @@ func loadRules() EntityRules {
 					{
 						Label:         "state",
 						NrdbLabelName: "state",
+					},
+				},
+			},
+			{
+				ProviderName: "windows_service_process",
+				MetricType:   "gauge",
+				NrdbName:     "windows_service_process",
+				EnumMetric:   true,
+				Attributes: []Attribute{
+					{
+						Label:            "name",
+						NrdbLabelName:    "service_name",
+						IsEntityMetadata: true,
+					},
+					{
+						Label:            "process_id",
+						NrdbLabelName:    "process_id",
+						IsEntityMetadata: true,
 					},
 				},
 			},

--- a/win_build.ps1
+++ b/win_build.ps1
@@ -21,8 +21,8 @@ $commitHash = (git rev-parse HEAD)
 
 $exporterRepo = "github.com/prometheus-community/windows_exporter"
 $exporterBinaryName = "windows_exporter.exe"
-# Commit used by v0.16.0 of windows_exporter
-$exporterVersion = "1c199e6c0eed881fb09dfcc84eee191262215e5e"
+# Commit used by v0.30.rc-2 of windows_exporter
+$exporterVersion = "f5ff75ebc26c5b4dd3f1d07701e6fca9fd944fe3"
 # Collector used by the Windows Service integration
 $collectors = "collector.go","wmi.go","perflib.go","service.go","cs.go"
 
@@ -112,7 +112,7 @@ if (-Not $skipExporterCompile)
     }
 
     # remove unused collectors 
-    Remove-Item .\collector\* -Exclude $collectors
+    # Remove-Item .\collector\* -Exclude $collectors
     $ErrorActionPreference = "SilentlyContinue"
     go mod download
     $ErrorActionPreference = "Stop"

--- a/win_build.ps1
+++ b/win_build.ps1
@@ -23,8 +23,7 @@ $exporterRepo = "github.com/prometheus-community/windows_exporter"
 $exporterBinaryName = "windows_exporter.exe"
 # Commit used by v0.29.2 of windows_exporter
 $exporterVersion = "622813343f930c121c8b1c061d6dd6f02d96015f"
-# Collector used by the Windows Service integration
-$collectors = "collector.go","wmi.go","perflib.go","service.go","cs.go"
+
 
 $env:GOPATH = go env GOPATH
 $env:GOBIN = "$env:GOPATH\bin"
@@ -111,8 +110,6 @@ if (-Not $skipExporterCompile)
         exit -1
     }
 
-    # remove unused collectors 
-    # Remove-Item .\collector\* -Exclude $collectors
     $ErrorActionPreference = "SilentlyContinue"
     go mod download
     $ErrorActionPreference = "Stop"

--- a/win_build.ps1
+++ b/win_build.ps1
@@ -21,8 +21,8 @@ $commitHash = (git rev-parse HEAD)
 
 $exporterRepo = "github.com/prometheus-community/windows_exporter"
 $exporterBinaryName = "windows_exporter.exe"
-# Commit used by v0.30.rc-2 of windows_exporter
-$exporterVersion = "f5ff75ebc26c5b4dd3f1d07701e6fca9fd944fe3"
+# Commit used by v0.29.2 of windows_exporter
+$exporterVersion = "622813343f930c121c8b1c061d6dd6f02d96015f"
 # Collector used by the Windows Service integration
 $collectors = "collector.go","wmi.go","perflib.go","service.go","cs.go"
 


### PR DESCRIPTION
Upgrade windows exporter to [v0.29.2](https://github.com/prometheus-community/windows_exporter/releases/tag/v0.29.2) #215

latest exporter has a bunch of breaking changes which are taken care of mainly it fixes the bug in which takes ~500 sec to scrape metrics on a customer's machine.

There are 2 services returned by the windows_exporter 
`windows_service_info{display_name="",name="PrintNotify",path_name="",run_as=""} 1`
`windows_service_info{display_name="",name="WaaSMedicSvc",path_name="",run_as=""} 1`

In which display_name is missing the integration_test is failing, but It's passing for the Github Actions.
[Old-metrics.txt](https://github.com/user-attachments/files/18108987/Old-metrics.txt)
[latest-metric.txt](https://github.com/user-attachments/files/18160147/latest-metric.txt)


Significant/Breaking changes - 
1. The exporter moved the `process_id` from `windows_service_info` metric to `windows_service_process` metric, now we consume from `windows_service_process` and add it into  `windows_service_info` to maintain the existing JSON format. [https://github.com/prometheus-community/windows_exporter/pull/1584](url)
2. The exported chaned the name label value it is not longer lowercase and matches the exact windows service name, e.g. remoteregistry -> RemoteRegistry. Converting it back to lowercase to keep it consistent.