### PR TITLE
fix:Remove 32 bit windows support for nri-winservices

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This integration comes bundled with New Relic's Windows infrastructure agent. It
 
 To build the integration, run `win_build.ps1`. This PowerShell script takes care of building the project and the supported version of the integration, placing the binaries in `/target/bin`.
 
-> Note that only Windows is supported.
+> **Note:** Only 64-bit Windows (amd64) is supported. 32-bit Windows support has been removed.
 
 ## Testing
 

--- a/src/exporter/exporter.go
+++ b/src/exporter/exporter.go
@@ -1,3 +1,6 @@
+//go:build windows && amd64
+// +build windows,amd64
+
 /*
 * Copyright 2020 New Relic Corporation. All rights reserved.
 * SPDX-License-Identifier: Apache-2.0

--- a/src/matcher/matcher.go
+++ b/src/matcher/matcher.go
@@ -1,3 +1,6 @@
+//go:build windows && amd64
+// +build windows,amd64
+
 /*
 * Copyright 2020 New Relic Corporation. All rights reserved.
 * SPDX-License-Identifier: Apache-2.0

--- a/src/matcher/matcher_test.go
+++ b/src/matcher/matcher_test.go
@@ -1,3 +1,6 @@
+//go:build windows && amd64
+// +build windows,amd64
+
 /*
 * Copyright 2020 New Relic Corporation. All rights reserved.
 * SPDX-License-Identifier: Apache-2.0

--- a/src/nri/config.go
+++ b/src/nri/config.go
@@ -1,3 +1,6 @@
+//go:build windows && amd64
+// +build windows,amd64
+
 /*
 * Copyright 2020 New Relic Corporation. All rights reserved.
 * SPDX-License-Identifier: Apache-2.0

--- a/src/nri/config_test.go
+++ b/src/nri/config_test.go
@@ -1,3 +1,6 @@
+//go:build windows && amd64
+// +build windows,amd64
+
 /*
 * Copyright 2020 New Relic Corporation. All rights reserved.
 * SPDX-License-Identifier: Apache-2.0

--- a/src/nri/metricsProcesor.go
+++ b/src/nri/metricsProcesor.go
@@ -1,3 +1,6 @@
+//go:build windows && amd64
+// +build windows,amd64
+
 /*
 * Copyright 2020 New Relic Corporation. All rights reserved.
 * SPDX-License-Identifier: Apache-2.0

--- a/src/nri/metricsProcesor_test.go
+++ b/src/nri/metricsProcesor_test.go
@@ -1,3 +1,6 @@
+//go:build windows && amd64
+// +build windows,amd64
+
 /*
 * Copyright 2020 New Relic Corporation. All rights reserved.
 * SPDX-License-Identifier: Apache-2.0

--- a/src/nri/rules.go
+++ b/src/nri/rules.go
@@ -1,3 +1,6 @@
+//go:build windows && amd64
+// +build windows,amd64
+
 /*
 * Copyright 2020 New Relic Corporation. All rights reserved.
 * SPDX-License-Identifier: Apache-2.0

--- a/src/scraper/fetcher.go
+++ b/src/scraper/fetcher.go
@@ -1,3 +1,6 @@
+//go:build windows && amd64
+// +build windows,amd64
+
 /*
 * Copyright 2020 New Relic Corporation. All rights reserved.
 * SPDX-License-Identifier: Apache-2.0

--- a/src/scraper/fetcher_test.go
+++ b/src/scraper/fetcher_test.go
@@ -1,3 +1,6 @@
+//go:build windows && amd64
+// +build windows,amd64
+
 /*
 * Copyright 2020 New Relic Corporation. All rights reserved.
 * SPDX-License-Identifier: Apache-2.0

--- a/src/winservices.go
+++ b/src/winservices.go
@@ -1,3 +1,6 @@
+//go:build windows && amd64
+// +build windows,amd64
+
 /*
 * Copyright 2020 New Relic Corporation. All rights reserved.
 * SPDX-License-Identifier: Apache-2.0

--- a/win_build.ps1
+++ b/win_build.ps1
@@ -3,8 +3,8 @@
         This script verifies, tests, builds and packages a New Relic Infrastructure Integration
 #>
 param (
-    # Target architecture: amd64 (default) or 386
-    [ValidateSet("amd64", "386")]
+    # Target architecture: amd64 only (32-bit support removed)
+    [ValidateSet("amd64")]
     [string]$arch="amd64",
     [string]$version="v0.0.0",
     # Skip tests


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed or feature is introduced. 

# Checklist:

- [ ] I checked that Licenses of new dependencies is compliant with our guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have added comments in my code to clarify it
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that show my fix/feature works
- [ ] I cleaned the commit history, and they are following [the conventional commits pattern](https://www.conventionalcommits.org/en/v1.0.0/), es:
    
      `type(scope): what I have changed`

**Test scenarios:
Test 1: Official Build Script (64-bit):**

PS C:\Users\nravada\newrelic\nri-winservices> .\win_build.ps1 -skipTests -skipExporterCompile
--- Checking dependencies
--- Collecting files
--- Format check
--- Running Build
--- Collecting Go main files
generating winservices
creating nri-winservices.exe
PS C:\Users\nravada\newrelic\nri-winservices> Get-Item "target\bin\windows_amd64\nri-winservices.exe" | Format-Table Name, Length, LastWriteTime -AutoSize

Name                  Length LastWriteTime
----                  ------ -------------
nri-winservices.exe 18683904 12/1/2025 11:37:50 AM
PS C:\Users\nravada\newrelic\nri-winservices> .\target\bin\windows_amd64\nri-winservices.exe -version
integration version: v0.0.0 commit: 14cf858d387df95e6f1607e86fbb6bf3c95e8275

**Test 2: Direct Go Build (64-bit):**

PS C:\Users\nravada\newrelic\nri-winservices> go build -o "test_direct_amd64.exe" ./src/
PS C:\Users\nravada\newrelic\nri-winservices> Get-Item "test_direct_amd64.exe" | Format-Table Name, Length, LastWriteTime -AutoSize

Name                    Length LastWriteTime        
----                    ------ -------------        
test_direct_amd64.exe 18683392 12/1/2025 11:41:28 AM


PS C:\Users\nravada\newrelic\nri-winservices> .\test_direct_amd64.exe -version
integration version: v0.0.0 commit: default

**Test 3: Explicit 64-bit Go Build:**

PS C:\Users\nravada\newrelic\nri-winservices> $env:GOOS="windows"; $env:GOARCH="amd64"; go build -o "test_explicit_amd64.exe" ./src/; echo "Build completed with exit code: $LASTEXITCODE"
Build completed with exit code: 0
PS C:\Users\nravada\newrelic\nri-winservices> Get-Item "test_explicit_amd64.exe" | Format-Table Name, Length, LastWriteTime -AutoSize

Name                      Length LastWriteTime        
----                      ------ -------------
test_explicit_amd64.exe 18683392 12/1/2025 11:42:44 AM


PS C:\Users\nravada\newrelic\nri-winservices> .\test_explicit_amd64.exe -version
integration version: v0.0.0 commit: default

**Test 4: Try 32-bit Build with Build Script (Should Fail):**

PS C:\Users\nravada\newrelic\nri-winservices> .\win_build.ps1 -arch "386" -skipTests -skipExporterCompile 2>&1 | Select-Object -First 5
C:\Users\nravada\newrelic\nri-winservices\win_build.ps1 : Cannot validate argument on parameter 'arch'. 
The argument "386" does not belong to the set "amd64" specified by the ValidateSet attribute. Supply an    
argument that is in the set and then try the command again.
At line:1 char:23
+ .\win_build.ps1 -arch "386" -skipTests -skipExporterCompile 2>&1 | Se ...
+                       ~~~~~
    + CategoryInfo          : InvalidData: (:) [win_build.ps1], ParameterBindingValidationException        
    + FullyQualifiedErrorId : ParameterArgumentValidationError,win_build.ps1

**Test 5: Try Direct 32-bit Build (Should Fail):**

PS C:\Users\nravada\newrelic\nri-winservices> $env:GOOS="windows"; $env:GOARCH="386"; go build -o "test_386_blocked.exe" ./src/ 2>&1 | Select-Object -First 3
go : package github.com/newrelic/nri-winservices/src: build constraints exclude all Go files in 
C:\Users\nravada\newrelic\nri-winservices\src
At line:1 char:41
+ ... :GOARCH="386"; go build -o "test_386_blocked.exe" ./src/ 2>&1 | Selec ...
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (package github....winservices\src:String) [], RemoteExceptio  
   n
    + FullyQualifiedErrorId : NativeCommandError

PS C:\Users\nravada\newrelic\nri-winservices> Test-Path "test_386_blocked.exe"
False

**Test 6: Run Unit Tests (64-bit):**

PS C:\Users\nravada\newrelic\nri-winservices> go env GOARCH
arm64
PS C:\Users\nravada\newrelic\nri-winservices> powershell -Command "cd 'C:\Users\nravada\newrelic\nri-winservices'; `$env:GOARCH='amd64'; go test ./src/matcher/ ./src/nri/" 2>&1 | Select-String "PASS|FAIL|ok"

ok      github.com/newrelic/nri-winservices/src/matcher 0.412s
ok      github.com/newrelic/nri-winservices/src/nri     0.570s

**Summary:**
Build Method		64-bit (amd64)	32-bit (386)
Official Build Script	✅ Works		❌ Blocked
Direct Go Build		✅ Works		❌ Blocked
Explicit GOARCH	✅ Works		❌ Blocked
Unit Tests			✅ Pass		❌ Blocked


