### PR TITLE
security: add permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/pullRequestAndMergeMaster.yml
+++ b/.github/workflows/pullRequestAndMergeMaster.yml
@@ -5,6 +5,10 @@ on:
       - master
   pull_request:
     branches:
+
+permissions:
+  contents: read
+
 jobs:
   CreateAndPushWindowsExecutable:
     name: CreateAndPushWindowsExecutable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ on:
   release:
     types:
       - created
+
+permissions:
+  contents: read
+
 jobs:
   CreateAndPushWindowsExecutable:
     name: CreateAndPushWindowsExecutable

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -8,6 +8,10 @@ name: Repolinter Action
 # filtered in the "Test Default Branch" step.
 on: [push, workflow_dispatch]
 
+
+permissions:
+  contents: read
+
 jobs:
   repolint:
     name: Run Repolinter

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: "0 3 * * *"
 
+
+permissions:
+  contents: read
+
 jobs:
   trivy:
     name: Trivy security scan


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to all workflow files missing a permissions block
- Follows the principle of least privilege for GitHub Actions tokens
- Resolves CodeQL alert `actions/missing-workflow-permissions` ([NR-560212](https://new-relic.atlassian.net/browse/NR-560212))

## Test plan
- [ ] Verify CI workflows still pass with the new permissions block
- [ ] Confirm CodeQL alert is resolved after merge

[NR-560212]: https://new-relic.atlassian.net/browse/NR-560212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ