### PR TITLE
update go version to fix vulnerabilities (1.25.9 → 1.25.10)

### DIFF
--- a/.github/workflows/pullRequestAndMergeMaster.yml
+++ b/.github/workflows/pullRequestAndMergeMaster.yml
@@ -10,7 +10,7 @@ jobs:
     name: CreateAndPushWindowsExecutable
     strategy:
       matrix:
-        go: [ 1.25.9 ]
+        go: [ 1.25.10 ]
         goarch: [ amd64 ]
     runs-on: windows-2022
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     name: CreateAndPushWindowsExecutable
     strategy:
       matrix:
-        go: [ 1.25.9 ]
+        go: [ 1.25.10 ]
         goarch: [ amd64 ]
     runs-on: windows-2022
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/nri-winservices
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/newrelic/infra-integrations-sdk/v4 v4.2.1


### PR DESCRIPTION
## Summary

Addresses [NR-564347](https://new-relic.atlassian.net/browse/NR-564347) — Trivy/Grype flag 11 CVEs per OHAI component (6 HIGH, 5 MEDIUM) resolved by upgrading to **Go 1.25.10** or 1.26.3.

Bumps `go.mod` and both CI workflow matrices from 1.25.9 → 1.25.10. Mirrors the prior 1.25.8 → 1.25.9 bump (#236).

## Test plan

- [x] `GOOS=windows GOARCH=amd64 go build ./src/...` — passes locally
- [ ] CI unit tests on push (Windows runtime required — tests cannot run on the PR author's macOS host)

### Note for reviewers

`go vet` flags ~20 pre-existing warnings about `protoimpl.MessageState` mutex copies in `src/scraper/fetcher.go` and `src/nri/metricsProcesor.go`. Verified these exist identically on current `master` — they are not introduced by this bump.

[NR-564347]: https://new-relic.atlassian.net/browse/NR-564347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ